### PR TITLE
New schema

### DIFF
--- a/abis/T.json
+++ b/abis/T.json
@@ -1,0 +1,434 @@
+[
+  { "inputs": [], "stateMutability": "nonpayable", "type": "constructor" },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "delegator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "fromDelegate",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "toDelegate",
+        "type": "address"
+      }
+    ],
+    "name": "DelegateChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "delegate",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "previousBalance",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newBalance",
+        "type": "uint256"
+      }
+    ],
+    "name": "DelegateVotesChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DELEGATION_TYPEHASH",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "DOMAIN_SEPARATOR",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "PERMIT_TYPEHASH",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "address", "name": "", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" },
+      { "internalType": "bytes", "name": "extraData", "type": "bytes" }
+    ],
+    "name": "approveAndCall",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "balanceOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "burn",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "burnFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "cachedChainId",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "cachedDomainSeparator",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" },
+      { "internalType": "uint32", "name": "pos", "type": "uint32" }
+    ],
+    "name": "checkpoints",
+    "outputs": [
+      {
+        "components": [
+          { "internalType": "uint32", "name": "fromBlock", "type": "uint32" },
+          { "internalType": "uint96", "name": "votes", "type": "uint96" }
+        ],
+        "internalType": "struct Checkpoints.Checkpoint",
+        "name": "checkpoint",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "internalType": "uint8", "name": "", "type": "uint8" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "delegatee", "type": "address" }
+    ],
+    "name": "delegate",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "signatory", "type": "address" },
+      { "internalType": "address", "name": "delegatee", "type": "address" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" },
+      { "internalType": "uint8", "name": "v", "type": "uint8" },
+      { "internalType": "bytes32", "name": "r", "type": "bytes32" },
+      { "internalType": "bytes32", "name": "s", "type": "bytes32" }
+    ],
+    "name": "delegateBySig",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "delegates",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "blockNumber", "type": "uint256" }
+    ],
+    "name": "getPastTotalSupply",
+    "outputs": [{ "internalType": "uint96", "name": "", "type": "uint96" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" },
+      { "internalType": "uint256", "name": "blockNumber", "type": "uint256" }
+    ],
+    "name": "getPastVotes",
+    "outputs": [{ "internalType": "uint96", "name": "", "type": "uint96" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "getVotes",
+    "outputs": [{ "internalType": "uint96", "name": "", "type": "uint96" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "recipient", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "mint",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "nonce",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "numCheckpoints",
+    "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" },
+      { "internalType": "uint8", "name": "v", "type": "uint8" },
+      { "internalType": "bytes32", "name": "r", "type": "bytes32" },
+      { "internalType": "bytes32", "name": "s", "type": "bytes32" }
+    ],
+    "name": "permit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "contract IERC20", "name": "token", "type": "address" },
+      { "internalType": "address", "name": "recipient", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "recoverERC20",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC721",
+        "name": "token",
+        "type": "address"
+      },
+      { "internalType": "address", "name": "recipient", "type": "address" },
+      { "internalType": "uint256", "name": "tokenId", "type": "uint256" },
+      { "internalType": "bytes", "name": "data", "type": "bytes" }
+    ],
+    "name": "recoverERC721",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "recipient", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "address", "name": "recipient", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/schema.graphql
+++ b/schema.graphql
@@ -13,11 +13,12 @@ type Account @entity {
 }
 
 type StakeData @entity {
-  id: ID! # staking provider address
-  owner: Account! # address
+  # Staking provider address.
+  id: ID!
+  owner: Account!
   stakeType: StakeType!
-  beneficiary: Bytes! # address
-  authorizer: Bytes! # address
+  beneficiary: Bytes!
+  authorizer: Bytes!
   tStake: BigInt!
   keepInTStake: BigInt!
   nuInTStake: BigInt!

--- a/schema.graphql
+++ b/schema.graphql
@@ -8,6 +8,7 @@ type Account @entity {
   # Id is the ethereum address of the account.
   id: ID!
   stakes: [StakeData!] @derivedFrom(field: "owner")
+  delegatee: TokenholderDelegation
   # TODO add more fields example `tokenBalances`.
 }
 
@@ -17,6 +18,7 @@ type StakeData @entity {
   stakeType: StakeType!
   beneficiary: Bytes! # address
   authorizer: Bytes! # address
+  delegatee: StakeDelegation
 }
 
 type EpochStake @entity {
@@ -39,10 +41,32 @@ type EpochCounter @entity {
   count: Int!
 }
 
-type Delegation @entity {
+interface Delegation {
+  # The delegatee address
   id: ID!
-  delegator: Bytes! # address
-  delegate: Bytes! # address
+  totalWeight: BigInt!
+}
+
+type StakeDelegation implements Delegation @entity {
+  # The delegatee address
+  id: ID!
+  totalWeight: BigInt!
+  stakeDelegators: [StakeData!] @derivedFrom(field: "delegatee")
+}
+
+type TokenholderDelegation implements Delegation @entity {
+  # The delegatee address
+  id: ID!
+  # The voting weight from the snapshot mechanism in the token and staking
+  # contracts. For Tokenholder DAO, there are currently two voting power
+  # sources:
+  # - Liquid T, tracked by the T token contract
+  # - Stakes in the T network, tracked  by the T staking contract. Note that
+  #   this also tracks legacy stakes (NU/KEEP); legacy stakes count for
+  #   tokenholders' voting power, but not for the total voting power of the
+  #   Tokenholder DAO."
+  totalWeight: BigInt!
+  delegators: [Account!] @derivedFrom(field: "delegatee")
 }
 
 type ConfirmedOperator @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -18,6 +18,10 @@ type StakeData @entity {
   stakeType: StakeType!
   beneficiary: Bytes! # address
   authorizer: Bytes! # address
+  tStake: BigInt!
+  keepInTStake: BigInt!
+  nuInTStake: BigInt!
+  totalStaked: BigInt!
   delegatee: StakeDelegation
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -70,6 +70,7 @@ type TokenholderDelegation implements Delegation @entity {
   #   tokenholders' voting power, but not for the total voting power of the
   #   Tokenholder DAO."
   totalWeight: BigInt!
+  liquidWeight: BigInt!
   delegators: [Account!] @derivedFrom(field: "delegatee")
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -7,14 +7,14 @@ enum StakeType {
 type Account @entity {
   # Id is the ethereum address of the account.
   id: ID!
+  stakes: [StakeData!] @derivedFrom(field: "owner")
   # TODO add more fields example `tokenBalances`.
 }
 
 type StakeData @entity {
   id: ID! # staking provider address
+  owner: Account! # address
   stakeType: StakeType!
-  owner: Bytes! # address
-  stakingProvider: Bytes! # address
   beneficiary: Bytes! # address
   authorizer: Bytes! # address
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,6 +1,6 @@
 enum StakeType {
-  NU,
-  KEEP,
+  NU
+  KEEP
   T
 }
 
@@ -75,7 +75,7 @@ type TokenholderDelegation implements Delegation @entity {
   # - Stakes in the T network, tracked  by the T staking contract. Note that
   #   this also tracks legacy stakes (NU/KEEP); legacy stakes count for
   #   tokenholders' voting power, but not for the total voting power of the
-  #   Tokenholder DAO."
+  #   Tokenholder DAO (as it's already accounted by the Vending Machines).
   totalWeight: BigInt!
   liquidWeight: BigInt!
   delegators: [Account!] @derivedFrom(field: "delegatee")

--- a/schema.graphql
+++ b/schema.graphql
@@ -4,6 +4,12 @@ enum StakeType {
   T
 }
 
+type Account @entity {
+  # Id is the ethereum address of the account.
+  id: ID!
+  # TODO add more fields example `tokenBalances`.
+}
+
 type StakeData @entity {
   id: ID! # staking provider address
   stakeType: StakeType!

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -6,6 +6,7 @@ import {
   Unstaked,
   DelegateChanged,
   TokenStaking,
+  DelegateVotesChanged,
 } from "../generated/TokenStaking/TokenStaking"
 import {
   StakeData,
@@ -353,9 +354,18 @@ export function handleDelegateChanged(event: DelegateChanged): void {
   ) as StakeData
   stake.delegatee = stakeDelegation.id
   stake.save()
-  // TODO: Set the total weight. Take into account all stakes because stake
-  // owners can delagate the voting power to the same `delegatee`.
-  stakeDelegation.totalWeight = BigInt.zero()
+  stakeDelegation.save()
+}
+
+export function handleDelegateVotesChanged(event: DelegateVotesChanged): void {
+  let delegatee = event.params.delegate
+  let stakeDelegation = StakeDelegation.load(delegatee.toHexString())
+
+  if (!stakeDelegation) {
+    stakeDelegation = new StakeDelegation(delegatee.toHexString())
+  }
+
+  stakeDelegation.totalWeight = event.params.newBalance
   stakeDelegation.save()
 }
 

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -14,7 +14,8 @@ import {
   Epoch,
   EpochStake,
   Delegation,
-  ConfirmedOperator
+  ConfirmedOperator,
+  Account,
 } from "../generated/schema"
 
 
@@ -39,9 +40,15 @@ export function handleStaked(event: Staked): void {
     default:
       type = "T"
   }
+  const owner = event.params.owner
+  let account = Account.load(owner.toHexString())
+  if(!account) {
+    account = new Account(owner.toHexString())
+    account.save()
+  }
+
   stakeData.stakeType = type
-  stakeData.owner = event.params.owner
-  stakeData.stakingProvider = event.params.stakingProvider
+  stakeData.owner = account.id
   stakeData.beneficiary = event.params.beneficiary
   stakeData.authorizer = event.params.authorizer
   stakeData.save()

--- a/src/threshold-token.ts
+++ b/src/threshold-token.ts
@@ -10,7 +10,7 @@ export function handleDelegateChanged(event: DelegateChanged): void {
   const delegatee = event.params.toDelegate
   const delegator = event.params.delegator
 
-  let delegation = getOrCreateTokenholderDelegation(delegatee)
+  const delegation = getOrCreateTokenholderDelegation(delegatee)
 
   let account = Account.load(delegator.toHexString())
   if (!account) {
@@ -20,16 +20,12 @@ export function handleDelegateChanged(event: DelegateChanged): void {
   account.delegatee = delegation.id
   account.save()
 
-  delegation.liquidWeight = BigInt.zero()
-  delegation.totalWeight = delegation.liquidWeight.plus(
-    getTotalWeightOfStakeDelegation(delegatee)
-  )
   delegation.save()
 }
 
 export function handleDelegateVotesChanged(event: DelegateVotesChanged): void {
-  let delegatee = event.params.delegate
-  let delegation = getOrCreateTokenholderDelegation(delegatee)
+  const delegatee = event.params.delegate
+  const delegation = getOrCreateTokenholderDelegation(delegatee)
 
   delegation.liquidWeight = event.params.newBalance
   delegation.totalWeight = delegation.liquidWeight.plus(

--- a/src/threshold-token.ts
+++ b/src/threshold-token.ts
@@ -1,0 +1,45 @@
+import { Address, BigInt } from "@graphprotocol/graph-ts"
+import {
+  DelegateChanged,
+  DelegateVotesChanged,
+} from "../generated/ThresholdToken/ThresholdToken"
+import { StakeDelegation, Account } from "../generated/schema"
+import { getOrCreateTokenholderDelegation, getStakeDelegationId } from "./utils"
+
+export function handleDelegateChanged(event: DelegateChanged): void {
+  const delegatee = event.params.toDelegate
+  const delegator = event.params.delegator
+
+  let delegation = getOrCreateTokenholderDelegation(delegatee)
+
+  let account = Account.load(delegator.toHexString())
+  if (!account) {
+    account = new Account(delegator.toHexString())
+  }
+
+  account.delegatee = delegation.id
+  account.save()
+
+  delegation.liquidWeight = BigInt.zero()
+  delegation.totalWeight = delegation.liquidWeight.plus(
+    getTotalWeightOfStakeDelegation(delegatee)
+  )
+  delegation.save()
+}
+
+export function handleDelegateVotesChanged(event: DelegateVotesChanged): void {
+  let delegatee = event.params.delegate
+  let delegation = getOrCreateTokenholderDelegation(delegatee)
+
+  delegation.liquidWeight = event.params.newBalance
+  delegation.totalWeight = delegation.liquidWeight.plus(
+    getTotalWeightOfStakeDelegation(delegatee)
+  )
+  delegation.save()
+}
+
+function getTotalWeightOfStakeDelegation(delegate: Address): BigInt {
+  const stakeDelegation = StakeDelegation.load(getStakeDelegationId(delegate))
+
+  return stakeDelegation ? stakeDelegation.totalWeight : BigInt.zero()
+}

--- a/src/utils/delegations.ts
+++ b/src/utils/delegations.ts
@@ -1,0 +1,29 @@
+import { Address } from "@graphprotocol/graph-ts"
+import { StakeDelegation, TokenholderDelegation } from "../../generated/schema"
+
+const STAKE_DELEGATION_ID_PREFIX = "stake-delegation-"
+const TOKEN_HOLDER_DELEGATION_ID_PREFIX = "tokenholder-delegation-"
+
+export function getStakeDelegationId(delegate: Address): string {
+  return `${STAKE_DELEGATION_ID_PREFIX}${delegate.toHexString()}`
+}
+
+export function getTokenholderDelegationId(delegate: Address): string {
+  return `${TOKEN_HOLDER_DELEGATION_ID_PREFIX}${delegate.toHexString()}`
+}
+
+export function getOrCreateStakeDelegation(delegate: Address): StakeDelegation {
+  const id = getStakeDelegationId(delegate)
+  const delegation = StakeDelegation.load(id)
+
+  return !delegation ? new StakeDelegation(id) : delegation
+}
+
+export function getOrCreateTokenholderDelegation(
+  delegate: Address
+): TokenholderDelegation {
+  const id = getTokenholderDelegationId(delegate)
+  const delegation = TokenholderDelegation.load(id)
+
+  return !delegation ? new TokenholderDelegation(id) : delegation
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./delegations"

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -51,10 +51,10 @@ dataSources:
         - name: ThresholdToken
           file: ./abis/T.json
       eventHandlers:
-      - event: DelegateChanged(indexed address,indexed address,indexed address)
-        handler: handleDelegateChanged
-      - event: DelegateVotesChanged(indexed address,uint256,uint256)
-        handler: handleDelegateVotesChanged
+        - event: DelegateChanged(indexed address,indexed address,indexed address)
+          handler: handleDelegateChanged
+        - event: DelegateVotesChanged(indexed address,uint256,uint256)
+          handler: handleDelegateVotesChanged
       file: ./src/threshold-token.ts
   - kind: ethereum
     name: SimplePREApplication

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -30,21 +30,6 @@ dataSources:
           handler: handleUnstaked
         - event: DelegateChanged(indexed address,indexed address,indexed address)
           handler: handleDelegateChanged
-      callHandlers:
-        - function: topUpKeep(address)
-          handler: handleTopUpKeep
-        - function: topUpNu(address)
-          handler: handleTopUpNu
-        - function: topUp(address,uint96)
-          handler: handleTopUpT
-        - function: unstakeKeep(address)
-          handler: handleUnstakeKeep
-        - function: unstakeT(address,uint96)
-          handler: handleUnstakeT
-        - function: unstakeNu(address,uint96)
-          handler: handleUnstakeNu
-        - function: unstakeAll(address)
-          handler: handleUnstakeAll
       file: ./src/mapping.ts
   - kind: ethereum
     name: SimplePREApplication

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -30,6 +30,8 @@ dataSources:
           handler: handleUnstaked
         - event: DelegateChanged(indexed address,indexed address,indexed address)
           handler: handleDelegateChanged
+        - event: DelegateVotesChanged(indexed address,uint256,uint256)
+          handler: handleDelegateVotesChanged
       file: ./src/mapping.ts
   - kind: ethereum
     name: SimplePREApplication

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -30,6 +30,21 @@ dataSources:
           handler: handleUnstaked
         - event: DelegateChanged(indexed address,indexed address,indexed address)
           handler: handleDelegateChanged
+      callHandlers:
+        - function: topUpKeep(address)
+          handler: handleTopUpKeep
+        - function: topUpNu(address)
+          handler: handleTopUpNu
+        - function: topUp(address,uint96)
+          handler: handleTopUpT
+        - function: unstakeKeep(address)
+          handler: handleUnstakeKeep
+        - function: unstakeT(address,uint96)
+          handler: handleUnstakeT
+        - function: unstakeNu(address,uint96)
+          handler: handleUnstakeNu
+        - function: unstakeAll(address)
+          handler: handleUnstakeAll
       file: ./src/mapping.ts
   - kind: ethereum
     name: SimplePREApplication

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -34,6 +34,29 @@ dataSources:
           handler: handleDelegateVotesChanged
       file: ./src/mapping.ts
   - kind: ethereum
+    name: ThresholdToken
+    network: mainnet
+    source:
+      address: "0xCdF7028ceAB81fA0C6971208e83fa7872994beE5"
+      abi: ThresholdToken
+      startBlock: 13912436
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      entities:
+        - StakeDelegation
+        - TokenholderDelegation
+      abis:
+        - name: ThresholdToken
+          file: ./abis/T.json
+      eventHandlers:
+      - event: DelegateChanged(indexed address,indexed address,indexed address)
+        handler: handleDelegateChanged
+      - event: DelegateVotesChanged(indexed address,uint256,uint256)
+        handler: handleDelegateVotesChanged
+      file: ./src/threshold-token.ts
+  - kind: ethereum
     name: SimplePREApplication
     network: mainnet
     source:


### PR DESCRIPTION
Depends on: #4 

This PR proposes the new schema of the Threshold Network Subgraph.

**What's changed**

1. Add `Account` entity.
Represents the base user data. We could add relationship with other entities in the future eg. `tokenBalances`.

2. Update `StakeData` entity:
- remove the `stakingProvider` field- the staking provider address can not be reused between delegations even if all tokens have been unstaked so we can surely use the staking provider address as the id,
- update the type of the `owner` field- add a relationship between `Account`. The owner(`Account`) can have multiple stakes,
- add the `delegatee` field- represented as `StakeDelegation` entity. The owner of the stake can delegate the voting power to a delegatee.
3. Add `StakeDelegation` entity.
 Represents the delegatee of the stakes. The delegatee can have more than one delegators and the `totalWeight` field should take into account all stakes.

4. Add `TokenholderDelegation` entity.
Represents the delegatee of the liquid tokens. The owner of the liquid tokens can delegate the voting power to delegate. For Tokenholder DAO, there are currently two voting power sources: liquid T and stakes in the T network so the total voting power in Tokenholder Dao is: `liquid voting power + stake voting power`.