### PR TITLE
Remove stakeType field from schema

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1,9 +1,3 @@
-enum StakeType {
-  NU
-  KEEP
-  T
-}
-
 type Account @entity {
   # Id is the ethereum address of the account.
   id: ID!
@@ -16,7 +10,6 @@ type StakeData @entity {
   # ID is the staking provider address
   id: ID!
   owner: Account!
-  stakeType: StakeType!
   beneficiary: Bytes!
   authorizer: Bytes!
   tStake: BigInt!

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -57,13 +57,12 @@ export function handleStaked(event: Staked): void {
     account.save()
   }
 
-  stakeData.stakeType = type
   stakeData.owner = account.id
   stakeData.beneficiary = event.params.beneficiary
   stakeData.authorizer = event.params.authorizer
   stakeData.tStake = type === "T" ? amount : BigInt.zero()
-  stakeData.nuInTStake = type === "NU" ? amount : BigInt.zero()
   stakeData.keepInTStake = type === "KEEP" ? amount : BigInt.zero()
+  stakeData.nuInTStake = type === "NU" ? amount : BigInt.zero()
   stakeData.totalStaked = stakeData.tStake
     .plus(stakeData.keepInTStake)
     .plus(stakeData.nuInTStake)


### PR DESCRIPTION
**Note: This PR must be merged after #8 .**

Delete field stakeType from StakeData: A stake can have different stake types at the same time (T, NuInTStake and KeepInTStake), so the field StakeType can be misleading.