### PR TITLE
Modify PRE operator schema's entity

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -78,11 +78,13 @@ type TokenholderDelegation implements Delegation @entity {
   delegators: [Account!] @derivedFrom(field: "delegatee")
 }
 
-type PREOperator @entity {
+type SimplePREApplication @entity {
   # ID is the staking provider address
   id: ID!
   operator: Bytes!
-  confirmationTimestamp: BigInt
+  stake: StakeData!
+  bondedTimestamp: BigInt!
+  confirmedTimestamp: BigInt
 }
 
 type DAOMetric @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -22,7 +22,7 @@ type StakeData @entity {
 type EpochStake @entity {
   # ID is the staking prov. add. + epoch counter
   id: ID!
-  stakingProvider: Bytes! # address
+  stakingProvider: Bytes!
   owner: Bytes!
   amount: BigInt!
 }
@@ -78,10 +78,11 @@ type TokenholderDelegation implements Delegation @entity {
   delegators: [Account!] @derivedFrom(field: "delegatee")
 }
 
-type ConfirmedOperator @entity {
+type PREOperator @entity {
+  # ID is the staking provider address
   id: ID!
-  stakingProvider: Bytes! # address
-  operator: Bytes! # address
+  operator: Bytes!
+  confirmationTimestamp: BigInt
 }
 
 type DAOMetric @entity {

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -64,8 +64,10 @@ export function handleStaked(event: Staked): void {
   stakeData.keepInTStake = type === "KEEP" ? amount : BigInt.zero()
   stakeData.nuInTStake = type === "NU" ? amount : BigInt.zero()
   stakeData.totalStaked = stakeData.tStake
-    .plus(stakeData.keepInTStake)
-    .plus(stakeData.nuInTStake)
+  stakeData.nuInTStake =
+    type === "NU"
+      ? amount
+      : BigInt.zero().plus(stakeData.keepInTStake).plus(stakeData.nuInTStake)
   stakeData.save()
 
   const lastEpoch = getOrCreateLastEpoch()

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -5,7 +5,10 @@ import {
   log,
   Address,
 } from "@graphprotocol/graph-ts"
-import { OperatorConfirmed } from "../generated/SimplePREApplication/SimplePREApplication"
+import {
+  OperatorBonded,
+  OperatorConfirmed,
+} from "../generated/SimplePREApplication/SimplePREApplication"
 import {
   Staked,
   ToppedUp,
@@ -19,9 +22,9 @@ import {
   StakeData,
   Epoch,
   EpochStake,
-  ConfirmedOperator,
   Account,
   MinStakeAmount,
+  PREOperator,
 } from "../generated/schema"
 import {
   getDaoMetric,
@@ -76,7 +79,7 @@ export function handleStaked(event: Staked): void {
   lastEpoch.save()
 
   const epochStakes = populateNewEpochStakes(lastEpoch.stakes)
-  const epochStakeId = getEpochStakeId(stakingProvider.toHexString())
+  const epochStakeId = getEpochStakeId(stakingProvider)
   const epochStake = new EpochStake(epochStakeId)
   epochStake.stakingProvider = stakingProvider
   epochStake.owner = owner
@@ -147,7 +150,7 @@ export function handleToppedUp(event: ToppedUp): void {
   lastEpoch.save()
 
   const epochStakes = populateNewEpochStakes(lastEpoch.stakes)
-  const epochStakeId = getEpochStakeId(stakingProvider.toHexString())
+  const epochStakeId = getEpochStakeId(stakingProvider)
   let epochStake = EpochStake.load(epochStakeId)
   if (!epochStake) {
     epochStake = new EpochStake(epochStakeId)
@@ -232,7 +235,7 @@ export function handleUnstaked(event: Unstaked): void {
   lastEpoch.save()
 
   const epochStakes = populateNewEpochStakes(lastEpoch.stakes)
-  const epochStakeId = getEpochStakeId(stakingProvider.toHexString())
+  const epochStakeId = getEpochStakeId(stakingProvider)
   const epochStake = EpochStake.load(epochStakeId)
   epochStake!.amount = epochStake!.amount.minus(amount)
   epochStake!.save()
@@ -282,16 +285,21 @@ export function handleDelegateVotesChanged(event: DelegateVotesChanged): void {
   daoMetric.save()
 }
 
-export function handleOperatorConfirmed(event: OperatorConfirmed): void {
-  let operator = ConfirmedOperator.load(
+export function handleOperatorBonded(event: OperatorBonded): void {
+  const preOperator = new PREOperator(
     event.params.stakingProvider.toHexString()
   )
-  if (!operator) {
-    operator = new ConfirmedOperator(event.params.stakingProvider.toHexString())
-  }
-  operator.stakingProvider = event.params.stakingProvider
-  operator.operator = event.params.operator
-  operator.save()
+  preOperator.operator = event.params.operator
+  preOperator.save()
+}
+
+export function handleOperatorConfirmed(event: OperatorConfirmed): void {
+  const preOperator = new PREOperator(
+    event.params.stakingProvider.toHexString()
+  )
+  preOperator.operator = event.params.operator
+  preOperator.confirmationTimestamp = event.block.timestamp
+  preOperator.save()
 }
 
 export function handleMinStakeAmountChanged(

--- a/src/utils/applications.ts
+++ b/src/utils/applications.ts
@@ -1,0 +1,14 @@
+import { Address } from "@graphprotocol/graph-ts"
+import { SimplePREApplication } from "../../generated/schema"
+
+export function getOrCreatePreApplication(
+  stakingProvider: Address
+): SimplePREApplication {
+  const preApplication = SimplePREApplication.load(
+    stakingProvider.toHexString()
+  )
+
+  return !preApplication
+    ? new SimplePREApplication(stakingProvider.toHexString())
+    : preApplication
+}

--- a/src/utils/epochs.ts
+++ b/src/utils/epochs.ts
@@ -1,12 +1,15 @@
-import { BigInt } from "@graphprotocol/graph-ts"
+import { Address, BigInt } from "@graphprotocol/graph-ts"
 import { Epoch, EpochStake, EpochCounter } from "../../generated/schema"
 
 const STAKING_CONTRACT_DEPLOY_TIMESTAMP = 1643633638
 const EPOCH_COUNTER_ID = "epoch-counter"
 
-export function getEpochStakeId(stakingProvider: string): string {
-  const epochCount = getEpochCount()
-  return `${stakingProvider}-${epochCount}`
+export function getEpochStakeId(
+  stakingProvider: Address,
+  epoch: i32 = -1
+): string {
+  const epochCount = epoch == -1 ? getEpochCount() : epoch
+  return `${stakingProvider.toHexString()}-${epochCount}`
 }
 
 export function getOrCreateLastEpoch(): Epoch {
@@ -27,7 +30,8 @@ export function getOrCreateLastEpoch(): Epoch {
 export function populateNewEpochStakes(stakes: string[]): string[] {
   for (let i = 0; i < stakes.length; i++) {
     const epochStake = EpochStake.load(stakes[i])
-    epochStake!.id = getEpochStakeId(epochStake!.stakingProvider.toHexString())
+    const stakingProvider = Address.fromBytes(epochStake!.stakingProvider)
+    epochStake!.id = getEpochStakeId(stakingProvider)
     epochStake!.save()
     stakes[i] = epochStake!.id
   }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from "./delegations"
 export * from "./epochs"
+export * from "./applications"

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -71,7 +71,7 @@ dataSources:
       apiVersion: 0.0.5
       language: wasm/assemblyscript
       entities:
-        - PREOperator
+        - SimplePREApplication
       abis:
         - name: SimplePREApplication
           file: ./abis/SimplePREApplication.json

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -71,11 +71,13 @@ dataSources:
       apiVersion: 0.0.5
       language: wasm/assemblyscript
       entities:
-        - Operator
+        - PREOperator
       abis:
         - name: SimplePREApplication
           file: ./abis/SimplePREApplication.json
       eventHandlers:
         - event: OperatorConfirmed(indexed address,indexed address)
           handler: handleOperatorConfirmed
+        - event: OperatorBonded(indexed address,indexed address,uint256)
+          handler: handleOperatorBonded
       file: ./src/mapping.ts


### PR DESCRIPTION
**Note: This PR must be merged after graphprotocol/graph-tooling#1108.**

Schema's changes:
- Entity name changed to PREOperator, which is more descriptive.
- Added OperatorBonded event handler, so PREOperator instance is created when a new operator is bonded.
- Added confirmationTimestamp field, which will store the time in which the operator is confirmed.
      
Other changes:
- Update getEpochStakeId function. This function from utils returns a string with the Epoch Stake's ID. Now it accepts an epoch ID. If this is not passed, it takes the current epoch count. Also, the staking provider argument type have changed from String to Address for simplicity.