### PR TITLE
Split mappings file according to contract event emitter

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -36,17 +36,17 @@ type Epoch @entity {
   stakes: [EpochStake!]!
 }
 
+type EpochCounter @entity {
+  # Singleton entity, id = epoch-counter
+  id: ID!
+  count: Int!
+}
+
 type MinStakeAmount @entity {
   id: ID!
   amount: BigInt!
   updatedAt: BigInt!
   blockNumber: BigInt!
-}
-
-type EpochCounter @entity {
-  # Singleton entity, id = epoch-counter
-  id: ID!
-  count: Int!
 }
 
 interface Delegation {

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -7,10 +7,6 @@ import {
   Address,
 } from "@graphprotocol/graph-ts"
 import {
-  OperatorBonded,
-  OperatorConfirmed,
-} from "../generated/SimplePREApplication/SimplePREApplication"
-import {
   Staked,
   ToppedUp,
   Unstaked,
@@ -284,33 +280,6 @@ export function handleDelegateVotesChanged(event: DelegateVotesChanged): void {
   const difference = event.params.newBalance.minus(event.params.previousBalance)
   daoMetric.stakedTotal = daoMetric.stakedTotal.plus(difference)
   daoMetric.save()
-}
-
-export function handleOperatorBonded(event: OperatorBonded): void {
-  const stakingProvider = event.params.stakingProvider
-  const operator = event.params.operator
-  const timestamp = event.params.startTimestamp
-
-  const preApplication = getOrCreatePreApplication(stakingProvider)
-  if (operator === Address.zero()) {
-    store.remove("SimplePREApplication", stakingProvider.toHexString())
-  } else {
-    preApplication.operator = operator
-    preApplication.stake = stakingProvider.toHexString()
-    preApplication.bondedTimestamp = timestamp.plus(BigInt.fromString("12"))
-    preApplication.save()
-  }
-}
-
-export function handleOperatorConfirmed(event: OperatorConfirmed): void {
-  const stakingProvider = event.params.stakingProvider
-  const operator = event.params.operator
-  const timestamp = event.block.timestamp
-
-  const preApplication = getOrCreatePreApplication(stakingProvider)
-  preApplication.operator = operator
-  preApplication.confirmedTimestamp = timestamp
-  preApplication.save()
 }
 
 export function handleMinStakeAmountChanged(

--- a/src/pre-app.ts
+++ b/src/pre-app.ts
@@ -1,0 +1,33 @@
+import {
+  OperatorBonded,
+  OperatorConfirmed,
+} from "../generated/SimplePREApplication/SimplePREApplication"
+import { PREOperator } from "../generated/schema"
+
+export function handleOperatorBonded(event: OperatorBonded): void {
+  const stakingProvider = event.params.stakingProvider
+  const operator = event.params.operator
+  const timestamp = event.params.startTimestamp
+
+  const preApplication = getOrCreatePreApplication(stakingProvider)
+  if (operator === Address.zero()) {
+    store.remove("SimplePREApplication", stakingProvider.toHexString())
+  } else {
+    preApplication.operator = operator
+    preApplication.stake = stakingProvider.toHexString()
+    preApplication.bondedTimestamp = timestamp.plus(BigInt.fromString("12"))
+    preApplication.save()
+  }
+}
+
+export function handleOperatorConfirmed(event: OperatorConfirmed): void {
+  const stakingProvider = event.params.stakingProvider
+  const operator = event.params.operator
+  const timestamp = event.block.timestamp
+
+  const preApplication = getOrCreatePreApplication(stakingProvider)
+  preApplication.operator = operator
+  preApplication.confirmedTimestamp = timestamp
+  preApplication.save()
+}
+

--- a/src/pre-app.ts
+++ b/src/pre-app.ts
@@ -1,8 +1,9 @@
+import { store, Address } from "@graphprotocol/graph-ts"
 import {
   OperatorBonded,
   OperatorConfirmed,
 } from "../generated/SimplePREApplication/SimplePREApplication"
-import { PREOperator } from "../generated/schema"
+import { getOrCreatePreApplication } from "./utils"
 
 export function handleOperatorBonded(event: OperatorBonded): void {
   const stakingProvider = event.params.stakingProvider
@@ -15,7 +16,7 @@ export function handleOperatorBonded(event: OperatorBonded): void {
   } else {
     preApplication.operator = operator
     preApplication.stake = stakingProvider.toHexString()
-    preApplication.bondedTimestamp = timestamp.plus(BigInt.fromString("12"))
+    preApplication.bondedTimestamp = timestamp
     preApplication.save()
   }
 }
@@ -30,4 +31,3 @@ export function handleOperatorConfirmed(event: OperatorConfirmed): void {
   preApplication.confirmedTimestamp = timestamp
   preApplication.save()
 }
-

--- a/src/staking.ts
+++ b/src/staking.ts
@@ -1,5 +1,4 @@
 import {
-  store,
   crypto,
   ByteArray,
   BigInt,
@@ -31,7 +30,6 @@ import {
   increaseEpochCount,
   getOrCreateStakeDelegation,
   getOrCreateTokenholderDelegation,
-  getOrCreatePreApplication,
 } from "./utils"
 
 export function handleStaked(event: Staked): void {

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -14,10 +14,12 @@ dataSources:
       apiVersion: 0.0.5
       language: wasm/assemblyscript
       entities:
-        - Staked
-        - ToppedUp
-        - Unstaked
-        - DelegateChanged
+        - Account
+        - StakeData
+        - EpochStake
+        - Epoch
+        - EpochCounter
+        - MinStakeAmount
       abis:
         - name: TokenStaking
           file: ./abis/TokenStaking.json
@@ -34,7 +36,7 @@ dataSources:
           handler: handleDelegateChanged
         - event: DelegateVotesChanged(indexed address,uint256,uint256)
           handler: handleDelegateVotesChanged
-      file: ./src/mapping.ts
+      file: ./src/staking.ts
   - kind: ethereum
     name: ThresholdToken
     network: mainnet
@@ -80,4 +82,4 @@ dataSources:
           handler: handleOperatorConfirmed
         - event: OperatorBonded(indexed address,indexed address,uint256)
           handler: handleOperatorBonded
-      file: ./src/mapping.ts
+      file: ./src/pre-app.ts


### PR DESCRIPTION
**Note: This PR must be merged after #11** 

The Threshold Subgraph receives events from several sources (contracts). So a logical division of events handlers can be each contract.
    
To achieve this, the generic `mappings.ts` file has been split into `pre-app.ts` and `staking.ts`.
    
Also, the `TokenStaking` entities list in subgraph manifest has been updated.