### PR TITLE
Avoid non-null assertions operators

### DIFF
--- a/src/staking.ts
+++ b/src/staking.ts
@@ -232,10 +232,12 @@ export function handleUnstaked(event: Unstaked): void {
   const epochStakes = populateNewEpochStakes(lastEpoch.stakes)
   const epochStakeId = getEpochStakeId(stakingProvider)
   const epochStake = EpochStake.load(epochStakeId)
-  epochStake!.amount = epochStake!.amount.minus(amount)
-  epochStake!.save()
-  if (epochStake!.amount.isZero()) {
-    epochStakes.splice(epochStakes.indexOf(epochStakeId), 1)
+  if (epochStake) {
+    epochStake.amount = epochStake.amount.minus(amount)
+    epochStake.save()
+    if (epochStake.amount.isZero()) {
+      epochStakes.splice(epochStakes.indexOf(epochStakeId), 1)
+    }
   }
 
   const epoch = new Epoch(getEpochCount().toString())

--- a/src/utils/epochs.ts
+++ b/src/utils/epochs.ts
@@ -30,10 +30,12 @@ export function getOrCreateLastEpoch(): Epoch {
 export function populateNewEpochStakes(stakes: string[]): string[] {
   for (let i = 0; i < stakes.length; i++) {
     const epochStake = EpochStake.load(stakes[i])
-    const stakingProvider = Address.fromBytes(epochStake!.stakingProvider)
-    epochStake!.id = getEpochStakeId(stakingProvider)
-    epochStake!.save()
-    stakes[i] = epochStake!.id
+    if (epochStake) {
+      const stakingProvider = Address.fromBytes(epochStake.stakingProvider)
+      epochStake.id = getEpochStakeId(stakingProvider)
+      epochStake.save()
+      stakes[i] = epochStake.id
+    }
   }
 
   return stakes


### PR DESCRIPTION
**Note: This PR must be merged after #14**

The use of non-null assertions operators on Typescript is not recommended whenever possible. Avoiding the use of them let the compiler do the job of statically checking the code.