### PR TITLE
Fix NPM script for fixing code linting problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "prettier": "prettier --ignore-path .linterignore",
     "format": "yarn prettier --check",
     "format:fix": "yarn prettier --write",
-    "lint:format:fix": "yarn format:fix && yarn lint:fix",
+    "lint:format:fix": "yarn format:fix . && yarn lint:fix .",
     "codegen": "graph codegen",
     "build": "graph build",
     "deploy": "graph deploy --node https://api.studio.thegraph.com/deploy/ Threshold",


### PR DESCRIPTION
The script `yarn lint:fix` is composed of two commands: `yarn format`
and `yarn lint`. To work properly, it's required to indicate the files
or folders where the command will run. In this case: `.` for all files.