### PR TITLE
Fix totalStaked field in StakeData entity

### DIFF
--- a/src/staking.ts
+++ b/src/staking.ts
@@ -62,10 +62,8 @@ export function handleStaked(event: Staked): void {
   stakeData.keepInTStake = type === "KEEP" ? amount : BigInt.zero()
   stakeData.nuInTStake = type === "NU" ? amount : BigInt.zero()
   stakeData.totalStaked = stakeData.tStake
-  stakeData.nuInTStake =
-    type === "NU"
-      ? amount
-      : BigInt.zero().plus(stakeData.keepInTStake).plus(stakeData.nuInTStake)
+    .plus(stakeData.keepInTStake)
+    .plus(stakeData.nuInTStake)
   stakeData.save()
 
   const lastEpoch = getOrCreateLastEpoch()


### PR DESCRIPTION
**Note: First merge #18** 

The calculation of the amount of tokens staked in each stake was wrong
since the sum of tokens staked from Nu, Keep and T contracts was not
correct.