### PR TITLE
Fix use of empty values in GraphQL required fields

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -33,7 +33,7 @@ type Epoch @entity {
   timestamp: BigInt!
   duration: BigInt
   totalAmount: BigInt!
-  stakes: [EpochStake!]!
+  stakes: [EpochStake!]
 }
 
 type EpochCounter @entity {

--- a/src/staking.ts
+++ b/src/staking.ts
@@ -71,7 +71,11 @@ export function handleStaked(event: Staked): void {
   lastEpoch.duration = timestamp.minus(lastEpoch.timestamp)
   lastEpoch.save()
 
-  const epochStakes = populateNewEpochStakes(lastEpoch.stakes)
+  let epochStakes: string[] = []
+  if (lastEpoch.stakes) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    epochStakes = populateNewEpochStakes(lastEpoch.stakes!)
+  }
   const epochStakeId = getEpochStakeId(stakingProvider)
   const epochStake = new EpochStake(epochStakeId)
   epochStake.stakingProvider = stakingProvider
@@ -142,7 +146,11 @@ export function handleToppedUp(event: ToppedUp): void {
   lastEpoch.duration = timestamp.minus(lastEpoch.timestamp)
   lastEpoch.save()
 
-  const epochStakes = populateNewEpochStakes(lastEpoch.stakes)
+  let epochStakes: string[] = []
+  if (lastEpoch.stakes) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    epochStakes = populateNewEpochStakes(lastEpoch.stakes!)
+  }
   const epochStakeId = getEpochStakeId(stakingProvider)
   let epochStake = EpochStake.load(epochStakeId)
   if (!epochStake) {
@@ -227,7 +235,11 @@ export function handleUnstaked(event: Unstaked): void {
   lastEpoch.duration = timestamp.minus(lastEpoch.timestamp)
   lastEpoch.save()
 
-  const epochStakes = populateNewEpochStakes(lastEpoch.stakes)
+  let epochStakes: string[] = []
+  if (lastEpoch.stakes) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    epochStakes = populateNewEpochStakes(lastEpoch.stakes!)
+  }
   const epochStakeId = getEpochStakeId(stakingProvider)
   const epochStake = EpochStake.load(epochStakeId)
   if (epochStake) {

--- a/src/utils/delegations.ts
+++ b/src/utils/delegations.ts
@@ -1,4 +1,4 @@
-import { Address } from "@graphprotocol/graph-ts"
+import { Address, BigInt } from "@graphprotocol/graph-ts"
 import {
   StakeDelegation,
   TokenholderDelegation,
@@ -19,22 +19,39 @@ export function getTokenholderDelegationId(delegate: Address): string {
 
 export function getOrCreateStakeDelegation(delegate: Address): StakeDelegation {
   const id = getStakeDelegationId(delegate)
-  const delegation = StakeDelegation.load(id)
+  let delegation = StakeDelegation.load(id)
 
-  return !delegation ? new StakeDelegation(id) : delegation
+  if (!delegation) {
+    delegation = new StakeDelegation(id)
+    delegation.totalWeight = BigInt.zero()
+  }
+
+  return delegation
 }
 
 export function getOrCreateTokenholderDelegation(
   delegate: Address
 ): TokenholderDelegation {
   const id = getTokenholderDelegationId(delegate)
-  const delegation = TokenholderDelegation.load(id)
+  let delegation = TokenholderDelegation.load(id)
 
-  return !delegation ? new TokenholderDelegation(id) : delegation
+  if (!delegation) {
+    delegation = new TokenholderDelegation(id)
+    delegation.totalWeight = BigInt.zero()
+    delegation.liquidWeight = BigInt.zero()
+  }
+
+  return delegation
 }
 
 export function getDaoMetric(): DAOMetric {
-  const metrics = DAOMetric.load(DAO_METRICS_ID)
+  let metrics = DAOMetric.load(DAO_METRICS_ID)
 
-  return !metrics ? new DAOMetric(DAO_METRICS_ID) : metrics
+  if (!metrics) {
+    metrics = new DAOMetric(DAO_METRICS_ID)
+    metrics.liquidTotal = BigInt.zero()
+    metrics.stakedTotal = BigInt.zero()
+  }
+
+  return metrics
 }


### PR DESCRIPTION
The GraphQL entities defined in subgraph's schema can be composed of
optional and required fields. A field is marked as required using the
exclamation mark in its definition. When a field is marked as required,
this must contain a non-null and non-empty value.

Until now, in Threshold Network subgraph, there are several entities
whose required fields are initialized as empty values:

- `stakes` in `Epoch` entity.
- `totalWeight` in `StakeDelegation` entity.
- `totalWeight` and `liquidWeight` in `TokenholderDelegation` entity.
- `liquidTotal` and `stakedTotal` in `DAOMetric` entity.

The previous versions of The Graph node allowed to deploy subgraphs
with required fields set as empty or null, but with recent version, the
deployment fails with message: `Null value resolved for non-null field
name`.