### PR TITLE
Fix operator bonded and confirmed timestamps

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -98,9 +98,9 @@ type SimplePREApplication @entity {
   operator: Bytes!
   "Stake related to this PRE operator"
   stake: StakeData!
-  "UNIX timestamp in which operator was bonded"
-  bondedTimestamp: BigInt!
-  "UNIX timestamp in which operator was confirmed (or null if not yet confirmed)"
+  "UNIX timestamp in which an operator was bonded for this staking provider for first time"
+  bondedTimestamp: BigInt
+  "UNIX timestamp in which an operator was confirmed for this staking provider for first time"
   confirmedTimestamp: BigInt
 }
 

--- a/src/pre-app.ts
+++ b/src/pre-app.ts
@@ -16,7 +16,9 @@ export function handleOperatorBonded(event: OperatorBonded): void {
   } else {
     preApplication.operator = operator
     preApplication.stake = stakingProvider.toHexString()
-    preApplication.bondedTimestamp = timestamp
+    if (!preApplication.bondedTimestamp) {
+      preApplication.bondedTimestamp = timestamp
+    }
     preApplication.save()
   }
 }
@@ -28,6 +30,8 @@ export function handleOperatorConfirmed(event: OperatorConfirmed): void {
 
   const preApplication = getOrCreatePreApplication(stakingProvider)
   preApplication.operator = operator
-  preApplication.confirmedTimestamp = timestamp
+  if (!preApplication.confirmedTimestamp) {
+    preApplication.confirmedTimestamp = timestamp
+  }
   preApplication.save()
 }


### PR DESCRIPTION
Up to now, the field `bondedTimestamp` and `confirmedTimestamp` on `SimplePREApplication` subgraph entity contains the timestamps of the last event received. This can be a problem if a staker changes its operator since this timestamp will be taken for rewards calculation, so the time in which the previous operator was running will not be taken into account.

The fix consists of not overwriting these timestamps when a new `bonded operator` or `confirmed operator` event is received.