### PR TITLE
Add code formatting intallation  to yarn lifecycle

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -74,12 +74,6 @@ $ yarn lint:fix <file_path>
 $ yarn format:lint:fix <file_path>  # fix files using Prettier and ESLint
 ```
 
-We encourage to use Git hooks to check code style. To install Git hooks, run:
-
-```
-$ yarn husky install
-```
-
 == Test the subgraph locally
 
 === Run local chain eg. Ganache

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "threshold-subgraph",
   "license": "GPL-3.0-or-later",
   "scripts": {
+    "prepare": "husky install",
     "lint": "eslint --ignore-path .linterignore",
     "lint:fix": "yarn lint --fix",
     "prettier": "prettier --ignore-path .linterignore",


### PR DESCRIPTION
Up to now, it was necessary to run "husky install" after running `yarn install` in order to get the pre-commit hooks running.

Adding a "prepare" script with this installation in the package.json will set-up Prettier and ESLint when yarn install is run.