### PR TITLE
Add new GraphQL entity "AppAuthorization"

### DIFF
--- a/subgraphs/mainnet/schema.graphql
+++ b/subgraphs/mainnet/schema.graphql
@@ -22,6 +22,7 @@ type StakeData @entity {
   "Staked T token total amount (T + KEEP in T + Nu in T)"
   totalStaked: BigInt!
   delegatee: StakeDelegation
+  authorizations: [AppAuthorization!] @derivedFrom(field: "stake")
 }
 
 "EpochStake represents a single stake in a single epoch"
@@ -53,6 +54,22 @@ type EpochCounter @entity {
   "ID is 'epoch-counter' (singleton entity)"
   id: ID!
   count: Int!
+}
+
+"AppAuthorizations represents the stake authorizations to Threshold apps"
+type AppAuthorization @entity {
+  "ID is <application address>-<staking provider address>"
+  id: ID!
+  "Application contract address"
+  appAddress: Bytes!
+  "Stake data of the staking provider"
+  stake: StakeData!
+  "Amount of total T currently authorized to the application"
+  amount: BigInt!
+  "Amount of T that will remain after the deauthorization process"
+  amountDeauthorizingTo: BigInt!
+  "Application name (if known)"
+  appName: String
 }
 
 "MinStakeAmount represents the minimum amount of tokens to stake"

--- a/subgraphs/mainnet/src/staking.ts
+++ b/subgraphs/mainnet/src/staking.ts
@@ -13,6 +13,10 @@ import {
   TokenStaking,
   DelegateVotesChanged,
   MinimumStakeAmountSet,
+  AuthorizationDecreaseApproved as AuthorizationDecreaseApprovedEvent,
+  AuthorizationDecreaseRequested as AuthorizationDecreaseRequestedEvent,
+  AuthorizationIncreased as AuthorizationIncreasedEvent,
+  AuthorizationInvoluntaryDecreased as AuthorizationInvoluntaryDecreasedEvent,
 } from "../generated/TokenStaking/TokenStaking"
 import {
   StakeData,
@@ -20,6 +24,7 @@ import {
   EpochStake,
   Account,
   MinStakeAmount,
+  AppAuthorization,
 } from "../generated/schema"
 import {
   getDaoMetric,
@@ -313,4 +318,56 @@ export function handleMinStakeAmountChanged(
   minStake.blockNumber = event.block.number
   minStake.updatedAt = event.block.timestamp
   minStake.save()
+}
+
+export function handleAuthorizationIncreased(
+  event: AuthorizationIncreasedEvent
+): void {
+  const tacoAddr = "0x347cc7ede7e5517bd47d20620b2cf1b406edcf07"
+  const tbtcAddr = "0x46d52e41c2f300bc82217ce22b920c34995204eb"
+  const randomBeaconAddr = "0x5499f54b4a1cb4816eefcf78962040461be3d80b"
+
+  const stakingProvider = event.params.stakingProvider
+  const appAddress = event.params.application
+  const toAmount = event.params.toAmount
+
+  const id = `${stakingProvider.toHexString()}-${appAddress.toHexString()}`
+  let appAuthorization = AppAuthorization.load(id)
+  if (!appAuthorization) {
+    appAuthorization = new AppAuthorization(id)
+  }
+
+  let appName = ""
+  if (appAddress.equals(ByteArray.fromHexString(tacoAddr))) {
+    appName = "TACo"
+  } else if (appAddress.equals(ByteArray.fromHexString(tbtcAddr))) {
+    appName = "tBTC"
+  } else if (appAddress.equals(ByteArray.fromHexString(randomBeaconAddr))) {
+    appName = "Random Beacon"
+  }
+
+  appAuthorization.appAddress = appAddress
+  appAuthorization.stake = stakingProvider.toHexString()
+  appAuthorization.amount = toAmount
+  appAuthorization.amountDeauthorizingTo = BigInt.zero()
+  appAuthorization.appName = appName
+  appAuthorization.save()
+}
+
+export function handleAuthorizationDecreaseApproved(
+  event: AuthorizationDecreaseApprovedEvent
+): void {
+  const a = "a"
+}
+
+export function handleAuthorizationDecreaseRequested(
+  event: AuthorizationDecreaseRequestedEvent
+): void {
+  const a = "a"
+}
+
+export function handleAuthorizationInvoluntaryDecreased(
+  event: AuthorizationInvoluntaryDecreasedEvent
+): void {
+  const a = "a"
 }

--- a/subgraphs/mainnet/src/staking.ts
+++ b/subgraphs/mainnet/src/staking.ts
@@ -357,17 +357,57 @@ export function handleAuthorizationIncreased(
 export function handleAuthorizationDecreaseApproved(
   event: AuthorizationDecreaseApprovedEvent
 ): void {
-  const a = "a"
+  const stakingProvider = event.params.stakingProvider
+  const appAddress = event.params.application
+  const toAmount = event.params.toAmount
+
+  const id = `${stakingProvider.toHexString()}-${appAddress.toHexString()}`
+  const appAuthorization = AppAuthorization.load(id)
+
+  if (!appAuthorization) {
+    return
+  }
+
+  appAuthorization.amount = toAmount
+  appAuthorization.amountDeauthorizingTo = BigInt.zero()
+  appAuthorization.save()
 }
 
 export function handleAuthorizationDecreaseRequested(
   event: AuthorizationDecreaseRequestedEvent
 ): void {
-  const a = "a"
+  const stakingProvider = event.params.stakingProvider
+  const appAddress = event.params.application
+  const toAmount = event.params.toAmount
+
+  const id = `${stakingProvider.toHexString()}-${appAddress.toHexString()}`
+  const appAuthorization = AppAuthorization.load(id)
+
+  if (!appAuthorization) {
+    return
+  }
+
+  appAuthorization.amountDeauthorizingTo = toAmount
+  appAuthorization.save()
 }
 
 export function handleAuthorizationInvoluntaryDecreased(
   event: AuthorizationInvoluntaryDecreasedEvent
 ): void {
-  const a = "a"
+  const stakingProvider = event.params.stakingProvider
+  const appAddress = event.params.application
+  const toAmount = event.params.toAmount
+
+  const id = `${stakingProvider.toHexString()}-${appAddress.toHexString()}`
+  const appAuthorization = AppAuthorization.load(id)
+
+  if (!appAuthorization) {
+    return
+  }
+
+  appAuthorization.amount = toAmount
+  if (appAuthorization.amountDeauthorizingTo > appAuthorization.amount) {
+    appAuthorization.amountDeauthorizingTo = appAuthorization.amount
+  }
+  appAuthorization.save()
 }

--- a/subgraphs/mainnet/subgraph.yaml
+++ b/subgraphs/mainnet/subgraph.yaml
@@ -21,6 +21,7 @@ dataSources:
         - EpochStake
         - Epoch
         - EpochCounter
+        - AppAuthorization
         - MinStakeAmount
       abis:
         - name: TokenStaking
@@ -38,6 +39,14 @@ dataSources:
           handler: handleDelegateChanged
         - event: DelegateVotesChanged(indexed address,uint256,uint256)
           handler: handleDelegateVotesChanged
+        - event: AuthorizationIncreased(indexed address,indexed address,uint96,uint96)
+          handler: handleAuthorizationIncreased
+        - event: AuthorizationDecreaseApproved(indexed address,indexed address,uint96,uint96)
+          handler: handleAuthorizationDecreaseApproved
+        - event: AuthorizationDecreaseRequested(indexed address,indexed address,uint96,uint96)
+          handler: handleAuthorizationDecreaseRequested
+        - event: AuthorizationInvoluntaryDecreased(indexed address,indexed address,uint96,uint96,indexed bool)
+          handler: handleAuthorizationInvoluntaryDecreased
       file: ./src/staking.ts
   - kind: ethereum
     name: ThresholdToken

--- a/subgraphs/mainnet/tests/staking-utils.ts
+++ b/subgraphs/mainnet/tests/staking-utils.ts
@@ -1,0 +1,42 @@
+import { newMockEvent } from "matchstick-as"
+import { AuthorizationIncreased } from "../generated/TokenStaking/TokenStaking"
+import { ethereum, Address, BigInt } from "@graphprotocol/graph-ts"
+
+export function createAuthorizationIncreasedEvent(
+  stakingProvider: Address,
+  application: Address,
+  fromAmount: BigInt,
+  toAmount: BigInt
+): AuthorizationIncreased {
+  const authorizationIncreasedEvent = changetype<AuthorizationIncreased>(
+    newMockEvent()
+  )
+  authorizationIncreasedEvent.parameters = []
+
+  authorizationIncreasedEvent.parameters.push(
+    new ethereum.EventParam(
+      "stakingProvider",
+      ethereum.Value.fromAddress(stakingProvider)
+    )
+  )
+  authorizationIncreasedEvent.parameters.push(
+    new ethereum.EventParam(
+      "application",
+      ethereum.Value.fromAddress(application)
+    )
+  )
+  authorizationIncreasedEvent.parameters.push(
+    new ethereum.EventParam(
+      "fromAmount",
+      ethereum.Value.fromUnsignedBigInt(fromAmount)
+    )
+  )
+  authorizationIncreasedEvent.parameters.push(
+    new ethereum.EventParam(
+      "toAmount",
+      ethereum.Value.fromUnsignedBigInt(toAmount)
+    )
+  )
+
+  return authorizationIncreasedEvent
+}

--- a/subgraphs/mainnet/tests/staking-utils.ts
+++ b/subgraphs/mainnet/tests/staking-utils.ts
@@ -1,5 +1,10 @@
 import { newMockEvent } from "matchstick-as"
-import { AuthorizationIncreased } from "../generated/TokenStaking/TokenStaking"
+import {
+  AuthorizationIncreased,
+  AuthorizationDecreaseApproved,
+  AuthorizationDecreaseRequested,
+  AuthorizationInvoluntaryDecreased,
+} from "../generated/TokenStaking/TokenStaking"
 import { ethereum, Address, BigInt } from "@graphprotocol/graph-ts"
 
 export function createAuthorizationIncreasedEvent(
@@ -39,4 +44,121 @@ export function createAuthorizationIncreasedEvent(
   )
 
   return authorizationIncreasedEvent
+}
+
+export function createAuthorizationDecreaseApprovedEvent(
+  stakingProvider: Address,
+  application: Address,
+  fromAmount: BigInt,
+  toAmount: BigInt
+): AuthorizationDecreaseApproved {
+  const authorizationDecreaseApprovedEvent =
+    changetype<AuthorizationDecreaseApproved>(newMockEvent())
+
+  authorizationDecreaseApprovedEvent.parameters = []
+
+  authorizationDecreaseApprovedEvent.parameters.push(
+    new ethereum.EventParam(
+      "stakingProvider",
+      ethereum.Value.fromAddress(stakingProvider)
+    )
+  )
+  authorizationDecreaseApprovedEvent.parameters.push(
+    new ethereum.EventParam(
+      "application",
+      ethereum.Value.fromAddress(application)
+    )
+  )
+  authorizationDecreaseApprovedEvent.parameters.push(
+    new ethereum.EventParam(
+      "fromAmount",
+      ethereum.Value.fromUnsignedBigInt(fromAmount)
+    )
+  )
+  authorizationDecreaseApprovedEvent.parameters.push(
+    new ethereum.EventParam(
+      "toAmount",
+      ethereum.Value.fromUnsignedBigInt(toAmount)
+    )
+  )
+
+  return authorizationDecreaseApprovedEvent
+}
+
+export function createAuthorizationDecreaseRequestedEvent(
+  stakingProvider: Address,
+  application: Address,
+  fromAmount: BigInt,
+  toAmount: BigInt
+): AuthorizationDecreaseRequested {
+  const authorizationDecreaseRequestedEvent =
+    changetype<AuthorizationDecreaseRequested>(newMockEvent())
+
+  authorizationDecreaseRequestedEvent.parameters = []
+
+  authorizationDecreaseRequestedEvent.parameters.push(
+    new ethereum.EventParam(
+      "stakingProvider",
+      ethereum.Value.fromAddress(stakingProvider)
+    )
+  )
+  authorizationDecreaseRequestedEvent.parameters.push(
+    new ethereum.EventParam(
+      "application",
+      ethereum.Value.fromAddress(application)
+    )
+  )
+  authorizationDecreaseRequestedEvent.parameters.push(
+    new ethereum.EventParam(
+      "fromAmount",
+      ethereum.Value.fromUnsignedBigInt(fromAmount)
+    )
+  )
+  authorizationDecreaseRequestedEvent.parameters.push(
+    new ethereum.EventParam(
+      "toAmount",
+      ethereum.Value.fromUnsignedBigInt(toAmount)
+    )
+  )
+
+  return authorizationDecreaseRequestedEvent
+}
+
+export function createAuthorizationInvoluntaryDecreasedEvent(
+  stakingProvider: Address,
+  application: Address,
+  fromAmount: BigInt,
+  toAmount: BigInt
+): AuthorizationInvoluntaryDecreased {
+  const authorizationInvoluntaryDecreasedEvent =
+    changetype<AuthorizationInvoluntaryDecreased>(newMockEvent())
+
+  authorizationInvoluntaryDecreasedEvent.parameters = []
+
+  authorizationInvoluntaryDecreasedEvent.parameters.push(
+    new ethereum.EventParam(
+      "stakingProvider",
+      ethereum.Value.fromAddress(stakingProvider)
+    )
+  )
+  authorizationInvoluntaryDecreasedEvent.parameters.push(
+    new ethereum.EventParam(
+      "application",
+      ethereum.Value.fromAddress(application)
+    )
+  )
+  authorizationInvoluntaryDecreasedEvent.parameters.push(
+    new ethereum.EventParam(
+      "fromAmount",
+      ethereum.Value.fromUnsignedBigInt(fromAmount)
+    )
+  )
+  authorizationInvoluntaryDecreasedEvent.parameters.push(
+    new ethereum.EventParam(
+      "toAmount",
+      ethereum.Value.fromUnsignedBigInt(toAmount)
+    )
+  )
+
+  return authorizationInvoluntaryDecreasedEvent
 }

--- a/subgraphs/mainnet/tests/staking.test.ts
+++ b/subgraphs/mainnet/tests/staking.test.ts
@@ -5,10 +5,22 @@ import {
   beforeAll,
   afterAll,
   clearStore,
+  beforeEach,
+  afterEach,
 } from "matchstick-as/assembly/index"
 import { Address, BigInt } from "@graphprotocol/graph-ts"
-import { createAuthorizationIncreasedEvent } from "./staking-utils"
-import { handleAuthorizationIncreased } from "../src/staking"
+import {
+  createAuthorizationDecreaseApprovedEvent,
+  createAuthorizationDecreaseRequestedEvent,
+  createAuthorizationIncreasedEvent,
+  createAuthorizationInvoluntaryDecreasedEvent,
+} from "./staking-utils"
+import {
+  handleAuthorizationDecreaseApproved,
+  handleAuthorizationDecreaseRequested,
+  handleAuthorizationIncreased,
+  handleAuthorizationInvoluntaryDecreased,
+} from "../src/staking"
 
 const tacoAppAddr = "0x347cc7ede7e5517bd47d20620b2cf1b406edcf07"
 const tbtcAddr = "0x46d52e41c2f300bc82217ce22b920c34995204eb"
@@ -120,6 +132,204 @@ describe("Application authorizations", () => {
       assert.fieldEquals("AppAuthorization", id, "stake", testStProvAddr)
       assert.fieldEquals("AppAuthorization", id, "amount", toAmount.toString())
       assert.fieldEquals("AppAuthorization", id, "amountDeauthorizingTo", "0")
+      assert.fieldEquals("AppAuthorization", id, "appName", "TACo")
+    })
+  })
+
+  describe("AuthorizationDecreaseApproved event", () => {
+    beforeAll(() => {
+      const stakingProvider = Address.fromString(testStProvAddr)
+      const tacoApp = Address.fromString(tacoAppAddr)
+      const fromAmount = BigInt.fromI32(testFromAmount)
+      const toAmount = BigInt.fromI32(testToAmount)
+
+      const authorizationIncreasedEvent = createAuthorizationIncreasedEvent(
+        stakingProvider,
+        tacoApp,
+        fromAmount,
+        toAmount
+      )
+      handleAuthorizationIncreased(authorizationIncreasedEvent)
+    })
+
+    afterAll(() => {
+      clearStore()
+    })
+
+    test("authorization for the application is lowered when event received", () => {
+      const stakingProvider = Address.fromString(testStProvAddr)
+      const tacoApp = Address.fromString(tacoAppAddr)
+      const fromAmount = BigInt.fromI32(testToAmount)
+      const toAmount = BigInt.fromI32(100)
+
+      const authorizationDecreaseApprovedEvent =
+        createAuthorizationDecreaseApprovedEvent(
+          stakingProvider,
+          tacoApp,
+          fromAmount,
+          toAmount
+        )
+      handleAuthorizationDecreaseApproved(authorizationDecreaseApprovedEvent)
+
+      const id = testStProvAddr + "-" + tacoAppAddr
+      assert.entityCount("AppAuthorization", 1)
+      assert.fieldEquals("AppAuthorization", id, "appAddress", tacoAppAddr)
+      assert.fieldEquals("AppAuthorization", id, "stake", testStProvAddr)
+      assert.fieldEquals("AppAuthorization", id, "amount", toAmount.toString())
+      assert.fieldEquals("AppAuthorization", id, "amountDeauthorizingTo", "0")
+      assert.fieldEquals("AppAuthorization", id, "appName", "TACo")
+    })
+  })
+
+  describe("AuthorizationDecreaseRequested event", () => {
+    beforeAll(() => {
+      const stakingProvider = Address.fromString(testStProvAddr)
+      const tacoApp = Address.fromString(tacoAppAddr)
+      const fromAmount = BigInt.fromI32(testFromAmount)
+      const toAmount = BigInt.fromI32(testToAmount)
+
+      const authorizationIncreasedEvent = createAuthorizationIncreasedEvent(
+        stakingProvider,
+        tacoApp,
+        fromAmount,
+        toAmount
+      )
+      handleAuthorizationIncreased(authorizationIncreasedEvent)
+    })
+
+    afterAll(() => {
+      clearStore()
+    })
+
+    test("deauthorizationAmount for the application is increased when event received", () => {
+      const stakingProvider = Address.fromString(testStProvAddr)
+      const tacoApp = Address.fromString(tacoAppAddr)
+      const fromAmount = BigInt.fromI32(testToAmount)
+      const toAmount = BigInt.fromI32(100)
+
+      const authorizationDecreaseRequestedEvent =
+        createAuthorizationDecreaseRequestedEvent(
+          stakingProvider,
+          tacoApp,
+          fromAmount,
+          toAmount
+        )
+      handleAuthorizationDecreaseRequested(authorizationDecreaseRequestedEvent)
+
+      const id = testStProvAddr + "-" + tacoAppAddr
+      assert.entityCount("AppAuthorization", 1)
+      assert.fieldEquals("AppAuthorization", id, "appAddress", tacoAppAddr)
+      assert.fieldEquals("AppAuthorization", id, "stake", testStProvAddr)
+      assert.fieldEquals(
+        "AppAuthorization",
+        id,
+        "amount",
+        testToAmount.toString()
+      )
+      assert.fieldEquals(
+        "AppAuthorization",
+        id,
+        "amountDeauthorizingTo",
+        toAmount.toString()
+      )
+      assert.fieldEquals("AppAuthorization", id, "appName", "TACo")
+    })
+  })
+
+  describe("AuthorizationInvoluntaryDecreased event", () => {
+    beforeEach(() => {
+      const stakingProvider = Address.fromString(testStProvAddr)
+      const tacoApp = Address.fromString(tacoAppAddr)
+      const fromAmount = BigInt.fromI32(testFromAmount)
+      const toAmount = BigInt.fromI32(testToAmount)
+
+      const authorizationIncreasedEvent = createAuthorizationIncreasedEvent(
+        stakingProvider,
+        tacoApp,
+        fromAmount,
+        toAmount
+      )
+      handleAuthorizationIncreased(authorizationIncreasedEvent)
+    })
+
+    afterEach(() => {
+      clearStore()
+    })
+
+    test("authorization decrease when event is received", () => {
+      const stakingProvider = Address.fromString(testStProvAddr)
+      const tacoApp = Address.fromString(tacoAppAddr)
+      const fromAmount = BigInt.fromI32(testToAmount)
+      const toAmount = BigInt.fromI32(100)
+
+      const authorizationInvoluntaryDecreasedEvent =
+        createAuthorizationInvoluntaryDecreasedEvent(
+          stakingProvider,
+          tacoApp,
+          fromAmount,
+          toAmount
+        )
+      handleAuthorizationInvoluntaryDecreased(
+        authorizationInvoluntaryDecreasedEvent
+      )
+
+      const id = testStProvAddr + "-" + tacoAppAddr
+      assert.entityCount("AppAuthorization", 1)
+      assert.fieldEquals("AppAuthorization", id, "appAddress", tacoAppAddr)
+      assert.fieldEquals("AppAuthorization", id, "stake", testStProvAddr)
+      assert.fieldEquals("AppAuthorization", id, "amount", toAmount.toString())
+      assert.fieldEquals("AppAuthorization", id, "amountDeauthorizingTo", "0")
+      assert.fieldEquals("AppAuthorization", id, "appName", "TACo")
+    })
+
+    test("if there is a deauthorization requested, amountDeauthorizingTo is decreased accordingly", () => {
+      const stakingProvider = Address.fromString(testStProvAddr)
+      const tacoApp = Address.fromString(tacoAppAddr)
+      const fromAmount = BigInt.fromI32(testToAmount)
+      const toAmountRequested = BigInt.fromI32(500)
+      const toAmountInvoluntaryDecreased = BigInt.fromI32(200)
+
+      const authorizationDecreaseRequestedEvent =
+        createAuthorizationDecreaseRequestedEvent(
+          stakingProvider,
+          tacoApp,
+          fromAmount,
+          toAmountRequested
+        )
+      handleAuthorizationDecreaseRequested(authorizationDecreaseRequestedEvent)
+
+      // Now, we have a pending deauthorization that will set the authorization
+      // amount to 500
+
+      const authorizationInvoluntaryDecreasedEvent =
+        createAuthorizationInvoluntaryDecreasedEvent(
+          stakingProvider,
+          tacoApp,
+          fromAmount,
+          toAmountInvoluntaryDecreased
+        )
+      handleAuthorizationInvoluntaryDecreased(
+        authorizationInvoluntaryDecreasedEvent
+      )
+
+      // But now, we have decreased the current authorization amount to 200
+
+      const id = testStProvAddr + "-" + tacoAppAddr
+      assert.fieldEquals("AppAuthorization", id, "appAddress", tacoAppAddr)
+      assert.fieldEquals("AppAuthorization", id, "stake", testStProvAddr)
+      assert.fieldEquals(
+        "AppAuthorization",
+        id,
+        "amount",
+        toAmountInvoluntaryDecreased.toString()
+      )
+      assert.fieldEquals(
+        "AppAuthorization",
+        id,
+        "amountDeauthorizingTo",
+        toAmountInvoluntaryDecreased.toString(),
+        "the deauthorizingTo amount must be set accordingly"
+      )
       assert.fieldEquals("AppAuthorization", id, "appName", "TACo")
     })
   })

--- a/subgraphs/mainnet/tests/staking.test.ts
+++ b/subgraphs/mainnet/tests/staking.test.ts
@@ -1,0 +1,126 @@
+import {
+  assert,
+  describe,
+  test,
+  beforeAll,
+  afterAll,
+  clearStore,
+} from "matchstick-as/assembly/index"
+import { Address, BigInt } from "@graphprotocol/graph-ts"
+import { createAuthorizationIncreasedEvent } from "./staking-utils"
+import { handleAuthorizationIncreased } from "../src/staking"
+
+const tacoAppAddr = "0x347cc7ede7e5517bd47d20620b2cf1b406edcf07"
+const tbtcAddr = "0x46d52e41c2f300bc82217ce22b920c34995204eb"
+const randomBeaconAddr = "0x5499f54b4a1cb4816eefcf78962040461be3d80b"
+const testStProvAddr = "0x1111111111111111111111111111111111111111"
+const testFromAmount = 0
+const testToAmount = 1000
+
+describe("Application authorizations", () => {
+  describe("AuthorizationIncreased event", () => {
+    beforeAll(() => {
+      const stakingProvider = Address.fromString(testStProvAddr)
+      const tacoApp = Address.fromString(tacoAppAddr)
+      const fromAmount = BigInt.fromI32(testFromAmount)
+      const toAmount = BigInt.fromI32(testToAmount)
+
+      const authorizationIncreasedEvent = createAuthorizationIncreasedEvent(
+        stakingProvider,
+        tacoApp,
+        fromAmount,
+        toAmount
+      )
+      handleAuthorizationIncreased(authorizationIncreasedEvent)
+    })
+
+    afterAll(() => {
+      clearStore()
+    })
+
+    test("a new AppAuthorization is created when AuthorizationIncreased for first time", () => {
+      const id = testStProvAddr + "-" + tacoAppAddr
+      assert.entityCount("AppAuthorization", 1)
+      assert.fieldEquals("AppAuthorization", id, "appAddress", tacoAppAddr)
+      assert.fieldEquals("AppAuthorization", id, "stake", testStProvAddr)
+      assert.fieldEquals(
+        "AppAuthorization",
+        id,
+        "amount",
+        testToAmount.toString()
+      )
+      assert.fieldEquals(
+        "AppAuthorization",
+        id,
+        "amountDeauthorizingTo",
+        testFromAmount.toString()
+      )
+      assert.fieldEquals("AppAuthorization", id, "appName", "TACo")
+    })
+
+    test("a new AppAuthorization is created for RandomBeacon", () => {
+      const stakingProvider = Address.fromString(testStProvAddr)
+      const app = Address.fromString(randomBeaconAddr)
+      const fromAmount = BigInt.fromI32(testFromAmount)
+      const toAmount = BigInt.fromI32(testToAmount)
+
+      const authorizationIncreasedEvent = createAuthorizationIncreasedEvent(
+        stakingProvider,
+        app,
+        fromAmount,
+        toAmount
+      )
+      handleAuthorizationIncreased(authorizationIncreasedEvent)
+
+      const id = stakingProvider.toHexString() + "-" + app.toHexString()
+      assert.entityCount("AppAuthorization", 2)
+      assert.fieldEquals("AppAuthorization", id, "appName", "Random Beacon")
+    })
+
+    test("a new AppAuthorization is created for tBTC", () => {
+      const stakingProvider = Address.fromString(testStProvAddr)
+      const app = Address.fromString(tbtcAddr)
+      const fromAmount = BigInt.fromI32(testFromAmount)
+      const toAmount = BigInt.fromI32(testToAmount)
+
+      const authorizationIncreasedEvent = createAuthorizationIncreasedEvent(
+        stakingProvider,
+        app,
+        fromAmount,
+        toAmount
+      )
+      handleAuthorizationIncreased(authorizationIncreasedEvent)
+
+      const id = stakingProvider.toHexString() + "-" + app.toHexString()
+      assert.entityCount("AppAuthorization", 3)
+      assert.fieldEquals("AppAuthorization", id, "appName", "tBTC")
+    })
+
+    test("an existing AppAuthorization is updated when AuthorizationIncreased", () => {
+      const stakingProvider = Address.fromString(testStProvAddr)
+      const tacoApp = Address.fromString(tacoAppAddr)
+      const fromAmount = BigInt.fromI32(testToAmount)
+      const toAmount = BigInt.fromI32(2000)
+
+      const authorizationIncreasedEvent = createAuthorizationIncreasedEvent(
+        stakingProvider,
+        tacoApp,
+        fromAmount,
+        toAmount
+      )
+      handleAuthorizationIncreased(authorizationIncreasedEvent)
+
+      const id = testStProvAddr + "-" + tacoAppAddr
+      assert.entityCount(
+        "AppAuthorization",
+        3,
+        "we have updated an existing entity, so same number must remain"
+      )
+      assert.fieldEquals("AppAuthorization", id, "appAddress", tacoAppAddr)
+      assert.fieldEquals("AppAuthorization", id, "stake", testStProvAddr)
+      assert.fieldEquals("AppAuthorization", id, "amount", toAmount.toString())
+      assert.fieldEquals("AppAuthorization", id, "amountDeauthorizingTo", "0")
+      assert.fieldEquals("AppAuthorization", id, "appName", "TACo")
+    })
+  })
+})


### PR DESCRIPTION
This PR will create a new GraphQL entity in the mainnet subgraph `AppAuthorization`.

This entity represents the stake authorizations given by stakes to Threshold apps.