### PR TITLE
Replace Deauthorizing field in AppAuthorization entity

### DIFF
--- a/subgraphs/mainnet/schema.graphql
+++ b/subgraphs/mainnet/schema.graphql
@@ -66,8 +66,8 @@ type AppAuthorization @entity {
   stake: StakeData!
   "Amount of total T currently authorized to the application"
   amount: BigInt!
-  "Amount of T that will remain after the deauthorization process"
-  amountDeauthorizingTo: BigInt!
+  "Amount of T that is being deauthorized"
+  amountDeauthorizing: BigInt!
   "Application name (if known)"
   appName: String
 }

--- a/subgraphs/mainnet/src/staking.ts
+++ b/subgraphs/mainnet/src/staking.ts
@@ -349,7 +349,7 @@ export function handleAuthorizationIncreased(
   appAuthorization.appAddress = appAddress
   appAuthorization.stake = stakingProvider.toHexString()
   appAuthorization.amount = toAmount
-  appAuthorization.amountDeauthorizingTo = BigInt.zero()
+  appAuthorization.amountDeauthorizing = BigInt.zero()
   appAuthorization.appName = appName
   appAuthorization.save()
 }
@@ -369,7 +369,7 @@ export function handleAuthorizationDecreaseApproved(
   }
 
   appAuthorization.amount = toAmount
-  appAuthorization.amountDeauthorizingTo = BigInt.zero()
+  appAuthorization.amountDeauthorizing = BigInt.zero()
   appAuthorization.save()
 }
 
@@ -379,6 +379,7 @@ export function handleAuthorizationDecreaseRequested(
   const stakingProvider = event.params.stakingProvider
   const appAddress = event.params.application
   const toAmount = event.params.toAmount
+  const fromAmount = event.params.fromAmount
 
   const id = `${stakingProvider.toHexString()}-${appAddress.toHexString()}`
   const appAuthorization = AppAuthorization.load(id)
@@ -387,7 +388,7 @@ export function handleAuthorizationDecreaseRequested(
     return
   }
 
-  appAuthorization.amountDeauthorizingTo = toAmount
+  appAuthorization.amountDeauthorizing = fromAmount.minus(toAmount)
   appAuthorization.save()
 }
 
@@ -406,8 +407,8 @@ export function handleAuthorizationInvoluntaryDecreased(
   }
 
   appAuthorization.amount = toAmount
-  if (appAuthorization.amountDeauthorizingTo > appAuthorization.amount) {
-    appAuthorization.amountDeauthorizingTo = appAuthorization.amount
+  if (appAuthorization.amountDeauthorizing > appAuthorization.amount) {
+    appAuthorization.amountDeauthorizing = appAuthorization.amount
   }
   appAuthorization.save()
 }

--- a/subgraphs/mainnet/tests/staking.test.ts
+++ b/subgraphs/mainnet/tests/staking.test.ts
@@ -64,7 +64,7 @@ describe("Application authorizations", () => {
       assert.fieldEquals(
         "AppAuthorization",
         id,
-        "amountDeauthorizingTo",
+        "amountDeauthorizing",
         testFromAmount.toString()
       )
       assert.fieldEquals("AppAuthorization", id, "appName", "TACo")
@@ -131,7 +131,7 @@ describe("Application authorizations", () => {
       assert.fieldEquals("AppAuthorization", id, "appAddress", tacoAppAddr)
       assert.fieldEquals("AppAuthorization", id, "stake", testStProvAddr)
       assert.fieldEquals("AppAuthorization", id, "amount", toAmount.toString())
-      assert.fieldEquals("AppAuthorization", id, "amountDeauthorizingTo", "0")
+      assert.fieldEquals("AppAuthorization", id, "amountDeauthorizing", "0")
       assert.fieldEquals("AppAuthorization", id, "appName", "TACo")
     })
   })
@@ -176,7 +176,7 @@ describe("Application authorizations", () => {
       assert.fieldEquals("AppAuthorization", id, "appAddress", tacoAppAddr)
       assert.fieldEquals("AppAuthorization", id, "stake", testStProvAddr)
       assert.fieldEquals("AppAuthorization", id, "amount", toAmount.toString())
-      assert.fieldEquals("AppAuthorization", id, "amountDeauthorizingTo", "0")
+      assert.fieldEquals("AppAuthorization", id, "amountDeauthorizing", "0")
       assert.fieldEquals("AppAuthorization", id, "appName", "TACo")
     })
   })
@@ -229,8 +229,8 @@ describe("Application authorizations", () => {
       assert.fieldEquals(
         "AppAuthorization",
         id,
-        "amountDeauthorizingTo",
-        toAmount.toString()
+        "amountDeauthorizing",
+        fromAmount.minus(toAmount).toString()
       )
       assert.fieldEquals("AppAuthorization", id, "appName", "TACo")
     })
@@ -278,11 +278,11 @@ describe("Application authorizations", () => {
       assert.fieldEquals("AppAuthorization", id, "appAddress", tacoAppAddr)
       assert.fieldEquals("AppAuthorization", id, "stake", testStProvAddr)
       assert.fieldEquals("AppAuthorization", id, "amount", toAmount.toString())
-      assert.fieldEquals("AppAuthorization", id, "amountDeauthorizingTo", "0")
+      assert.fieldEquals("AppAuthorization", id, "amountDeauthorizing", "0")
       assert.fieldEquals("AppAuthorization", id, "appName", "TACo")
     })
 
-    test("if there is a deauthorization requested, amountDeauthorizingTo is decreased accordingly", () => {
+    test("if there is a deauthorization requested, amountDeauthorizing is decreased accordingly", () => {
       const stakingProvider = Address.fromString(testStProvAddr)
       const tacoApp = Address.fromString(tacoAppAddr)
       const fromAmount = BigInt.fromI32(testToAmount)
@@ -326,7 +326,7 @@ describe("Application authorizations", () => {
       assert.fieldEquals(
         "AppAuthorization",
         id,
-        "amountDeauthorizingTo",
+        "amountDeauthorizing",
         toAmountInvoluntaryDecreased.toString(),
         "the deauthorizingTo amount must be set accordingly"
       )


### PR DESCRIPTION
With this change, the amount of T shown in this field is the amount that is going to be deauthorized when the authorization decrease is approved.

Up to now, this showed the final value of T authorized after the authorization decrease approvement, which is a bit confusing.