### PR TITLE
Add AppAuthHistory entity to subgraph

### DIFF
--- a/subgraphs/mainnet/schema.graphql
+++ b/subgraphs/mainnet/schema.graphql
@@ -58,7 +58,7 @@ type EpochCounter @entity {
 
 "AppAuthorizations represents the stake authorizations to Threshold apps"
 type AppAuthorization @entity {
-  "ID is <application address>-<staking provider address>"
+  "ID is <staking provider address>-<application address>"
   id: ID!
   "Application contract address"
   appAddress: Bytes!
@@ -70,6 +70,22 @@ type AppAuthorization @entity {
   amountDeauthorizingTo: BigInt!
   "Application name (if known)"
   appName: String
+}
+
+"AppAuthHistory stores each change in the stake's authorization of apps"
+type AppAuthHistory @entity(immutable: true) {
+  "IS is <staking provider address>-<application address>-<block number>"
+  id: ID!
+  "AppAuthorization of this update in the authorization"
+  appAuthorization: AppAuthorization!
+  "Amount of total T authorized by staking provider to the application in this block"
+  amount: BigInt!
+  "Type of event that caused this update"
+  eventType: String!
+  "Block in which this authorization update became effective"
+  blockNumber: BigInt!
+  "Timestamp in which this authorization update became effective"
+  timestamp: BigInt!
 }
 
 "MinStakeAmount represents the minimum amount of tokens to stake"

--- a/subgraphs/mainnet/src/staking.ts
+++ b/subgraphs/mainnet/src/staking.ts
@@ -25,6 +25,7 @@ import {
   Account,
   MinStakeAmount,
   AppAuthorization,
+  AppAuthHistory,
 } from "../generated/schema"
 import {
   getDaoMetric,
@@ -331,10 +332,10 @@ export function handleAuthorizationIncreased(
   const appAddress = event.params.application
   const toAmount = event.params.toAmount
 
-  const id = `${stakingProvider.toHexString()}-${appAddress.toHexString()}`
-  let appAuthorization = AppAuthorization.load(id)
+  const appAuthId = `${stakingProvider.toHexString()}-${appAddress.toHexString()}`
+  let appAuthorization = AppAuthorization.load(appAuthId)
   if (!appAuthorization) {
-    appAuthorization = new AppAuthorization(id)
+    appAuthorization = new AppAuthorization(appAuthId)
   }
 
   let appName = ""
@@ -352,6 +353,20 @@ export function handleAuthorizationIncreased(
   appAuthorization.amountDeauthorizingTo = BigInt.zero()
   appAuthorization.appName = appName
   appAuthorization.save()
+
+  const appAuthHistoryId =
+    stakingProvider.toHexString() +
+    "-" +
+    appAddress.toHexString() +
+    "-" +
+    event.block.number.toString()
+  const appAuthHistory = new AppAuthHistory(appAuthHistoryId)
+  appAuthHistory.appAuthorization = appAuthId
+  appAuthHistory.amount = toAmount
+  appAuthHistory.eventType = "AuthorizationIncreased"
+  appAuthHistory.blockNumber = event.block.number
+  appAuthHistory.timestamp = event.block.timestamp
+  appAuthHistory.save()
 }
 
 export function handleAuthorizationDecreaseApproved(
@@ -361,8 +376,8 @@ export function handleAuthorizationDecreaseApproved(
   const appAddress = event.params.application
   const toAmount = event.params.toAmount
 
-  const id = `${stakingProvider.toHexString()}-${appAddress.toHexString()}`
-  const appAuthorization = AppAuthorization.load(id)
+  const appAuthId = `${stakingProvider.toHexString()}-${appAddress.toHexString()}`
+  const appAuthorization = AppAuthorization.load(appAuthId)
 
   if (!appAuthorization) {
     return
@@ -371,6 +386,20 @@ export function handleAuthorizationDecreaseApproved(
   appAuthorization.amount = toAmount
   appAuthorization.amountDeauthorizingTo = BigInt.zero()
   appAuthorization.save()
+
+  const appAuthHistoryId =
+    stakingProvider.toHexString() +
+    "-" +
+    appAddress.toHexString() +
+    "-" +
+    event.block.number.toString()
+  const appAuthHistory = new AppAuthHistory(appAuthHistoryId)
+  appAuthHistory.appAuthorization = appAuthId
+  appAuthHistory.amount = toAmount
+  appAuthHistory.eventType = "AuthorizationDecreaseApproved"
+  appAuthHistory.blockNumber = event.block.number
+  appAuthHistory.timestamp = event.block.timestamp
+  appAuthHistory.save()
 }
 
 export function handleAuthorizationDecreaseRequested(
@@ -398,8 +427,8 @@ export function handleAuthorizationInvoluntaryDecreased(
   const appAddress = event.params.application
   const toAmount = event.params.toAmount
 
-  const id = `${stakingProvider.toHexString()}-${appAddress.toHexString()}`
-  const appAuthorization = AppAuthorization.load(id)
+  const appAuthId = `${stakingProvider.toHexString()}-${appAddress.toHexString()}`
+  const appAuthorization = AppAuthorization.load(appAuthId)
 
   if (!appAuthorization) {
     return
@@ -410,4 +439,18 @@ export function handleAuthorizationInvoluntaryDecreased(
     appAuthorization.amountDeauthorizingTo = appAuthorization.amount
   }
   appAuthorization.save()
+
+  const appAuthHistoryId =
+    stakingProvider.toHexString() +
+    "-" +
+    appAddress.toHexString() +
+    "-" +
+    event.block.number.toString()
+  const appAuthHistory = new AppAuthHistory(appAuthHistoryId)
+  appAuthHistory.appAuthorization = appAuthId
+  appAuthHistory.amount = toAmount
+  appAuthHistory.eventType = "AuthorizationInvoluntaryDecreased"
+  appAuthHistory.blockNumber = event.block.number
+  appAuthHistory.timestamp = event.block.timestamp
+  appAuthHistory.save()
 }

--- a/subgraphs/mainnet/tests/staking.test.ts
+++ b/subgraphs/mainnet/tests/staking.test.ts
@@ -334,3 +334,107 @@ describe("Application authorizations", () => {
     })
   })
 })
+
+describe("Application authorization history", () => {
+  afterAll(() => {
+    clearStore()
+  })
+
+  test("a new AppAuthHistory is created with AuthorizationIncreased event", () => {
+    const stakingProvider = Address.fromString(testStProvAddr)
+    const tacoApp = Address.fromString(tacoAppAddr)
+    const fromAmount = BigInt.fromI32(100)
+    const toAmount = BigInt.fromI32(500)
+
+    const authorizationIncreasedEvent = createAuthorizationIncreasedEvent(
+      stakingProvider,
+      tacoApp,
+      fromAmount,
+      toAmount
+    )
+    handleAuthorizationIncreased(authorizationIncreasedEvent)
+
+    const id =
+      stakingProvider.toHexString() + "-" + tacoApp.toHexString() + "-1"
+    assert.entityCount("AppAuthHistory", 1)
+    assert.fieldEquals(
+      "AppAuthHistory",
+      id,
+      "appAuthorization",
+      stakingProvider.toHexString() + "-" + tacoApp.toHexString()
+    )
+    assert.fieldEquals("AppAuthHistory", id, "amount", toAmount.toString())
+    assert.fieldEquals(
+      "AppAuthHistory",
+      id,
+      "eventType",
+      "AuthorizationIncreased"
+    )
+  })
+
+  test("a new AppAuthHistory is created with AuthorizationDecreaseApproved event", () => {
+    const stakingProvider = Address.fromString(testStProvAddr)
+    const tacoApp = Address.fromString(tacoAppAddr)
+    const fromAmount = BigInt.fromI32(500)
+    const toAmount = BigInt.fromI32(100)
+
+    const authorizationDecreaseApprovedEvent =
+      createAuthorizationDecreaseApprovedEvent(
+        stakingProvider,
+        tacoApp,
+        fromAmount,
+        toAmount
+      )
+    handleAuthorizationDecreaseApproved(authorizationDecreaseApprovedEvent)
+
+    const id =
+      stakingProvider.toHexString() + "-" + tacoApp.toHexString() + "-1"
+    assert.fieldEquals(
+      "AppAuthHistory",
+      id,
+      "appAuthorization",
+      stakingProvider.toHexString() + "-" + tacoApp.toHexString()
+    )
+    assert.fieldEquals("AppAuthHistory", id, "amount", toAmount.toString())
+    assert.fieldEquals(
+      "AppAuthHistory",
+      id,
+      "eventType",
+      "AuthorizationDecreaseApproved"
+    )
+  })
+
+  test("a new AppAuthHistory is created with AuthorizationInvoluntaryDecreased event", () => {
+    const stakingProvider = Address.fromString(testStProvAddr)
+    const tacoApp = Address.fromString(tacoAppAddr)
+    const fromAmount = BigInt.fromI32(500)
+    const toAmount = BigInt.fromI32(100)
+
+    const authorizationInvoluntaryDecreasedEvent =
+      createAuthorizationInvoluntaryDecreasedEvent(
+        stakingProvider,
+        tacoApp,
+        fromAmount,
+        toAmount
+      )
+    handleAuthorizationInvoluntaryDecreased(
+      authorizationInvoluntaryDecreasedEvent
+    )
+
+    const id =
+      stakingProvider.toHexString() + "-" + tacoApp.toHexString() + "-1"
+    assert.fieldEquals(
+      "AppAuthHistory",
+      id,
+      "appAuthorization",
+      stakingProvider.toHexString() + "-" + tacoApp.toHexString()
+    )
+    assert.fieldEquals("AppAuthHistory", id, "amount", toAmount.toString())
+    assert.fieldEquals(
+      "AppAuthHistory",
+      id,
+      "eventType",
+      "AuthorizationInvoluntaryDecreased"
+    )
+  })
+})


### PR DESCRIPTION
This new entity allows us to have a history of the authorizations for each stake and application.