### PR TITLE
Add commitment duration to TACoCommitment entity

### DIFF
--- a/subgraphs/mainnet/schema.graphql
+++ b/subgraphs/mainnet/schema.graphql
@@ -149,4 +149,6 @@ type TACoCommitment @entity(immutable: true) {
   id: ID!
   "Timestamp of the end of the lock-up"
   endCommitment: BigInt!
+  "Selected duration in month of the lock-up"
+  duration: Int!
 }

--- a/subgraphs/mainnet/src/taco-application.ts
+++ b/subgraphs/mainnet/src/taco-application.ts
@@ -27,9 +27,30 @@ export function handleOperatorBonded(event: OperatorBondedEvent): void {
 }
 
 export function handleCommitmentMade(event: CommitmentMadeEvent): void {
+  const commitment3Months = 7862400
+  const commitment6Months = 15724800
+  const commitment12Months = 31449600
+  const commitment18Months = 47174400
+
+  const endCommitment = event.params.endCommitment
+  const eventTimestamp = event.block.timestamp
+  const durationInSeconds = endCommitment.minus(eventTimestamp).toI32()
+
+  let duration = 0
+  if (durationInSeconds >= commitment18Months) {
+    duration = 18
+  } else if (durationInSeconds >= commitment12Months) {
+    duration = 12
+  } else if (durationInSeconds >= commitment6Months) {
+    duration = 6
+  } else if (durationInSeconds >= commitment3Months) {
+    duration = 3
+  }
+
   const tacoCommitment = new TACoCommitment(
     event.params.stakingProvider.toHexString()
   )
-  tacoCommitment.endCommitment = event.params.endCommitment
+  tacoCommitment.endCommitment = endCommitment
+  tacoCommitment.duration = duration
   tacoCommitment.save()
 }

--- a/subgraphs/mainnet/tests/taco-application.test.ts
+++ b/subgraphs/mainnet/tests/taco-application.test.ts
@@ -127,35 +127,42 @@ describe("TACo operators", () => {
 })
 
 describe("TACo commitments", () => {
-  beforeAll(() => {
-    const stakingProv = Address.fromString(firstStakingProviderAddr)
-    const endCommitment = BigInt.fromI32(firstBondedTimestamp)
+  afterAll(() => {
+    clearStore()
+  })
+
+  test("a new TACo commitment is made for 3 months", () => {
+    const stakingProv = Address.fromString(
+      "0x1111111111111111111111111111111111111111"
+    )
+    // timestamp of the events mocked is "1"
+    const endCommitment = BigInt.fromI32(7862400 + 1)
     const commitmentMadeEvent = createCommitmentMadeEvent(
       stakingProv,
       endCommitment
     )
     handleCommitmentMade(commitmentMadeEvent)
-  })
-
-  afterAll(() => {
-    clearStore()
-  })
-
-  test("a new TACo commitment is made", () => {
     assert.entityCount("TACoCommitment", 1)
     assert.fieldEquals(
       "TACoCommitment",
-      firstStakingProviderAddr,
+      stakingProv.toHexString(),
       "endCommitment",
-      firstBondedTimestamp.toString()
+      endCommitment.toString()
+    )
+    assert.fieldEquals(
+      "TACoCommitment",
+      stakingProv.toHexString(),
+      "duration",
+      "3"
     )
   })
 
-  test("a 2nd TACo commitment is made", () => {
+  test("a new TACo commitment is made for 6 months", () => {
     const stakingProv = Address.fromString(
       "0x2222222222222222222222222222222222222222"
     )
-    const endCommitment = BigInt.fromI32(firstBondedTimestamp)
+    // timestamp of the events mocked is "1"
+    const endCommitment = BigInt.fromI32(15724800 + 1)
     const commitmentMadeEvent = createCommitmentMadeEvent(
       stakingProv,
       endCommitment
@@ -166,7 +173,65 @@ describe("TACo commitments", () => {
       "TACoCommitment",
       stakingProv.toHexString(),
       "endCommitment",
-      firstBondedTimestamp.toString()
+      endCommitment.toString()
+    )
+    assert.fieldEquals(
+      "TACoCommitment",
+      stakingProv.toHexString(),
+      "duration",
+      "6"
+    )
+  })
+
+  test("a new TACo commitment is made for 12 months", () => {
+    const stakingProv = Address.fromString(
+      "0x3333333333333333333333333333333333333333"
+    )
+    // timestamp of the events mocked is "1"
+    const endCommitment = BigInt.fromI32(31449600 + 1)
+    const commitmentMadeEvent = createCommitmentMadeEvent(
+      stakingProv,
+      endCommitment
+    )
+    handleCommitmentMade(commitmentMadeEvent)
+    assert.entityCount("TACoCommitment", 3)
+    assert.fieldEquals(
+      "TACoCommitment",
+      stakingProv.toHexString(),
+      "endCommitment",
+      endCommitment.toString()
+    )
+    assert.fieldEquals(
+      "TACoCommitment",
+      stakingProv.toHexString(),
+      "duration",
+      "12"
+    )
+  })
+
+  test("a new TACo commitment is made for 18 months", () => {
+    const stakingProv = Address.fromString(
+      "0x4444444444444444444444444444444444444444"
+    )
+    // timestamp of the events mocked is "1"
+    const endCommitment = BigInt.fromI32(47174400 + 1)
+    const commitmentMadeEvent = createCommitmentMadeEvent(
+      stakingProv,
+      endCommitment
+    )
+    handleCommitmentMade(commitmentMadeEvent)
+    assert.entityCount("TACoCommitment", 4)
+    assert.fieldEquals(
+      "TACoCommitment",
+      stakingProv.toHexString(),
+      "endCommitment",
+      endCommitment.toString()
+    )
+    assert.fieldEquals(
+      "TACoCommitment",
+      stakingProv.toHexString(),
+      "duration",
+      "18"
     )
   })
 })


### PR DESCRIPTION
These changes will add the TACo lock-up duration (excluding the 6 months deauthorization delay) to the TACoCommitment entity.