### PR TITLE
Add stake history again

### DIFF
--- a/subgraphs/mainnet/schema.graphql
+++ b/subgraphs/mainnet/schema.graphql
@@ -16,7 +16,26 @@ type StakeData @entity {
   "Staked T token total amount"
   stakedAmount: BigInt!
   delegatee: StakeDelegation
+  stakeHistory: [StakeHistory!] @derivedFrom(field: "stake")
   authorizations: [AppAuthorization!] @derivedFrom(field: "stake")
+}
+
+"History of each stake"
+type StakeHistory @entity(immutable: true) {
+  "ID is <staking provider address>-<block number>"
+  id: ID!
+  "Stake data of the staking provider"
+  stake: StakeData!
+  "The amount that has been added or reduced"
+  eventAmount: BigInt!
+  "The total staked amount at this time"
+  stakedAmount: BigInt!
+  "The event that updated the staked amount: Staked, ToppedUp or Unstaked"
+  eventType: String!
+  "The Ethereum block number in which the stake was updated"
+  blockNumber: BigInt!
+  "The timestamp in which the stake was updated"
+  timestamp: BigInt!
 }
 
 "AppAuthorizations represents the stake authorizations to Threshold apps"
@@ -37,7 +56,7 @@ type AppAuthorization @entity {
 
 "AppAuthHistory stores each change in the stake's authorization of apps"
 type AppAuthHistory @entity(immutable: true) {
-  "IS is <staking provider address>-<application address>-<block number>"
+  "ID is <staking provider address>-<application address>-<block number>"
   id: ID!
   "AppAuthorization of this update in the authorization"
   appAuthorization: AppAuthorization!

--- a/subgraphs/mainnet/src/staking.ts
+++ b/subgraphs/mainnet/src/staking.ts
@@ -17,6 +17,7 @@ import {
   MinStakeAmount,
   AppAuthorization,
   AppAuthHistory,
+  StakeHistory,
 } from "../generated/schema"
 import {
   getDaoMetric,
@@ -40,6 +41,17 @@ export function handleStaked(event: StakedEvent): void {
   stakeData.authorizer = event.params.authorizer
   stakeData.stakedAmount = event.params.amount
   stakeData.save()
+
+  const stakeHistoryId =
+    stakingProvider.toHexString() + "-" + event.block.number.toString()
+  const stakeHistory = new StakeHistory(stakeHistoryId)
+  stakeHistory.stake = stakingProvider.toHexString()
+  stakeHistory.eventAmount = event.params.amount
+  stakeHistory.stakedAmount = stakeData.stakedAmount
+  stakeHistory.eventType = "Staked"
+  stakeHistory.blockNumber = event.block.number
+  stakeHistory.timestamp = event.block.timestamp
+  stakeHistory.save()
 }
 
 export function handleToppedUp(event: ToppedUpEvent): void {
@@ -54,6 +66,17 @@ export function handleToppedUp(event: ToppedUpEvent): void {
   }
   stakeData.stakedAmount = stakeData.stakedAmount.plus(event.params.amount)
   stakeData.save()
+
+  const stakeHistoryId =
+    stakingProvider.toHexString() + "-" + event.block.number.toString()
+  const stakeHistory = new StakeHistory(stakeHistoryId)
+  stakeHistory.stake = stakingProvider.toHexString()
+  stakeHistory.eventAmount = event.params.amount
+  stakeHistory.stakedAmount = stakeData.stakedAmount
+  stakeHistory.eventType = "ToppedUp"
+  stakeHistory.blockNumber = event.block.number
+  stakeHistory.timestamp = event.block.timestamp
+  stakeHistory.save()
 }
 
 export function handleUnstaked(event: UnstakedEvent): void {
@@ -68,6 +91,17 @@ export function handleUnstaked(event: UnstakedEvent): void {
   }
   stakeData.stakedAmount = stakeData.stakedAmount.minus(event.params.amount)
   stakeData.save()
+
+  const stakeHistoryId =
+    stakingProvider.toHexString() + "-" + event.block.number.toString()
+  const stakeHistory = new StakeHistory(stakeHistoryId)
+  stakeHistory.stake = stakingProvider.toHexString()
+  stakeHistory.eventAmount = event.params.amount
+  stakeHistory.stakedAmount = stakeData.stakedAmount
+  stakeHistory.eventType = "Unstaked"
+  stakeHistory.blockNumber = event.block.number
+  stakeHistory.timestamp = event.block.timestamp
+  stakeHistory.save()
 }
 
 export function handleDelegateChanged(event: DelegateChanged): void {

--- a/subgraphs/mainnet/tests/staking.test.ts
+++ b/subgraphs/mainnet/tests/staking.test.ts
@@ -179,7 +179,7 @@ describe("Staking", () => {
       )
       handleToppedUp(toppedUpEvent)
 
-      assert.entityCount("StakeData", 1)
+      assert.entityCount("StakeData", 1, "the number of entities should remain")
       assert.fieldEquals("StakeData", testStProv, "owner", testOwner)
       assert.fieldEquals(
         "StakeData",
@@ -205,6 +205,74 @@ describe("Staking", () => {
         testAmount.toString()
       )
     })
+  })
+})
+
+describe("StakeHistory", () => {
+  beforeAll(() => {
+    const stakedEvent = createStakedEvent(
+      testStakeType,
+      Address.fromString(testOwner),
+      Address.fromString(testStProv),
+      Address.fromString(testBeneficiary),
+      Address.fromString(testAuthorizer),
+      BigInt.fromI32(testAmount)
+    )
+    handleStaked(stakedEvent)
+  })
+
+  afterAll(() => {
+    clearStore()
+  })
+
+  test("a new staked event is received", () => {
+    const id = testStProv + "-" + "1"
+    assert.fieldEquals("StakeHistory", id, "stake", testStProv)
+    assert.fieldEquals("StakeHistory", id, "eventAmount", testAmount.toString())
+    assert.fieldEquals(
+      "StakeHistory",
+      id,
+      "stakedAmount",
+      testAmount.toString()
+    )
+    assert.fieldEquals("StakeHistory", id, "eventType", "Staked")
+  })
+
+  test("a new toppedUp event is received", () => {
+    const toppedUpEvent = createToppedUpEvent(
+      Address.fromString(testStProv),
+      BigInt.fromI32(testAmount)
+    )
+    handleToppedUp(toppedUpEvent)
+    const id = testStProv + "-" + "1"
+    assert.fieldEquals("StakeHistory", id, "stake", testStProv)
+    assert.fieldEquals("StakeHistory", id, "eventAmount", testAmount.toString())
+    assert.fieldEquals(
+      "StakeHistory",
+      id,
+      "stakedAmount",
+      (testAmount * 2).toString()
+    )
+    assert.fieldEquals("StakeHistory", id, "eventType", "ToppedUp")
+  })
+
+  test("a new unstaked event is received", () => {
+    const unstakedEvent = createUnstakedEvent(
+      Address.fromString(testStProv),
+      BigInt.fromI32(testAmount)
+    )
+    handleUnstaked(unstakedEvent)
+    const id = testStProv + "-" + "1"
+    assert.entityCount("StakeHistory", 1)
+    assert.fieldEquals("StakeHistory", id, "stake", testStProv)
+    assert.fieldEquals("StakeHistory", id, "eventAmount", testAmount.toString())
+    assert.fieldEquals(
+      "StakeHistory",
+      id,
+      "stakedAmount",
+      testAmount.toString()
+    )
+    assert.fieldEquals("StakeHistory", id, "eventType", "Unstaked")
   })
 })
 


### PR DESCRIPTION
These changes add historical data for stake and unstake actions.

This data was previously available but it was developed inefficiently. With the previous implementation, the entities created by the subgraph were> 405,000, so the indexing times were extensive and the indexer nodes in The Graph protocol needed a lot of storage and processing capacity.

With this new implementation, the total number of entities stored by indexers is ~5,000.