### PR TITLE
Add eventAmount field to app authorizations entity

### DIFF
--- a/subgraphs/mainnet/schema.graphql
+++ b/subgraphs/mainnet/schema.graphql
@@ -62,6 +62,8 @@ type AppAuthHistory @entity(immutable: true) {
   appAuthorization: AppAuthorization!
   "Amount of total T authorized by staking provider to the application in this block"
   amount: BigInt!
+  "Amount of T that has been increased or decreased"
+  eventAmount: BigInt!
   "Type of event that caused this update"
   eventType: String!
   "Block in which this authorization update became effective"

--- a/subgraphs/mainnet/src/staking.ts
+++ b/subgraphs/mainnet/src/staking.ts
@@ -195,6 +195,7 @@ export function handleAuthorizationIncreased(
   const appAuthHistory = new AppAuthHistory(appAuthHistoryId)
   appAuthHistory.appAuthorization = appAuthId
   appAuthHistory.amount = toAmount
+  appAuthHistory.eventAmount = toAmount.minus(event.params.fromAmount)
   appAuthHistory.eventType = "AuthorizationIncreased"
   appAuthHistory.blockNumber = event.block.number
   appAuthHistory.timestamp = event.block.timestamp
@@ -228,6 +229,7 @@ export function handleAuthorizationDecreaseApproved(
   const appAuthHistory = new AppAuthHistory(appAuthHistoryId)
   appAuthHistory.appAuthorization = appAuthId
   appAuthHistory.amount = toAmount
+  appAuthHistory.eventAmount = event.params.fromAmount.minus(toAmount)
   appAuthHistory.eventType = "AuthorizationDecreaseApproved"
   appAuthHistory.blockNumber = event.block.number
   appAuthHistory.timestamp = event.block.timestamp
@@ -282,6 +284,7 @@ export function handleAuthorizationInvoluntaryDecreased(
   const appAuthHistory = new AppAuthHistory(appAuthHistoryId)
   appAuthHistory.appAuthorization = appAuthId
   appAuthHistory.amount = toAmount
+  appAuthHistory.eventAmount = event.params.fromAmount.minus(toAmount)
   appAuthHistory.eventType = "AuthorizationInvoluntaryDecreased"
   appAuthHistory.blockNumber = event.block.number
   appAuthHistory.timestamp = event.block.timestamp

--- a/subgraphs/mainnet/tests/staking.test.ts
+++ b/subgraphs/mainnet/tests/staking.test.ts
@@ -614,6 +614,12 @@ describe("Application authorization history", () => {
     assert.fieldEquals(
       "AppAuthHistory",
       id,
+      "eventAmount",
+      toAmount.minus(fromAmount).toString()
+    )
+    assert.fieldEquals(
+      "AppAuthHistory",
+      id,
       "eventType",
       "AuthorizationIncreased"
     )
@@ -643,6 +649,12 @@ describe("Application authorization history", () => {
       stakingProvider.toHexString() + "-" + tacoApp.toHexString()
     )
     assert.fieldEquals("AppAuthHistory", id, "amount", toAmount.toString())
+    assert.fieldEquals(
+      "AppAuthHistory",
+      id,
+      "eventAmount",
+      fromAmount.minus(toAmount).toString()
+    )
     assert.fieldEquals(
       "AppAuthHistory",
       id,
@@ -677,6 +689,12 @@ describe("Application authorization history", () => {
       stakingProvider.toHexString() + "-" + tacoApp.toHexString()
     )
     assert.fieldEquals("AppAuthHistory", id, "amount", toAmount.toString())
+    assert.fieldEquals(
+      "AppAuthHistory",
+      id,
+      "eventAmount",
+      fromAmount.minus(toAmount).toString()
+    )
     assert.fieldEquals(
       "AppAuthHistory",
       id,


### PR DESCRIPTION
This change will add a field for the history authorization history. This field `eventAmount` shows how much the authorized amount has been increased or decreased.