### PR TITLE
Add OperatorConfirmed field

### DIFF
--- a/subgraphs/mainnet/schema.graphql
+++ b/subgraphs/mainnet/schema.graphql
@@ -125,6 +125,8 @@ type TACoOperator @entity {
   bondedTimestamp: BigInt!
   "Timestamp in which the first operator of this staking provider was bonded"
   bondedTimestampFirstOperator: BigInt
+  "The operator has been confirmed. This info depends on polygon->ethereum bridge/bot"
+  confirmed: Boolean
 }
 
 "TACo commitments made by a staking provider"

--- a/subgraphs/mainnet/src/taco-application.ts
+++ b/subgraphs/mainnet/src/taco-application.ts
@@ -1,6 +1,7 @@
-import { Address } from "@graphprotocol/graph-ts"
+import { Address, log } from "@graphprotocol/graph-ts"
 import {
   OperatorBonded as OperatorBondedEvent,
+  OperatorConfirmed as OperatorConfirmedEvent,
   CommitmentMade as CommitmentMadeEvent,
 } from "../generated/TACoApplication/TACoApplication"
 import { TACoOperator, TACoCommitment } from "../generated/schema"
@@ -22,7 +23,25 @@ export function handleOperatorBonded(event: OperatorBondedEvent): void {
   tacoOperator.bondedTimestamp = timestamp
   if (!tacoOperator.bondedTimestampFirstOperator) {
     tacoOperator.bondedTimestampFirstOperator = timestamp
+    tacoOperator.confirmed = false
   }
+  tacoOperator.save()
+}
+
+export function handleOperatorConfirmed(event: OperatorConfirmedEvent): void {
+  const stakingProvider = event.params.stakingProvider
+  const operator = event.params.operator
+
+  const tacoOperator = TACoOperator.load(stakingProvider.toHexString())
+  if (!tacoOperator) {
+    log.warning("Received an OperatorConfirmed event for unknown SP", [
+      stakingProvider.toHexString(),
+    ])
+    return
+  }
+
+  tacoOperator.operator = operator
+  tacoOperator.confirmed = true
   tacoOperator.save()
 }
 

--- a/subgraphs/mainnet/subgraph.yaml
+++ b/subgraphs/mainnet/subgraph.yaml
@@ -92,6 +92,8 @@ dataSources:
       eventHandlers:
         - event: OperatorBonded(indexed address,indexed address,indexed address,uint256)
           handler: handleOperatorBonded
+        - event: OperatorConfirmed(indexed address,indexed address)
+          handler: handleOperatorConfirmed
         - event: CommitmentMade(indexed address,uint256)
           handler: handleCommitmentMade
       file: ./src/taco-application.ts

--- a/subgraphs/mainnet/tests/taco-application-utils.ts
+++ b/subgraphs/mainnet/tests/taco-application-utils.ts
@@ -3,6 +3,7 @@ import { ethereum, Address, BigInt } from "@graphprotocol/graph-ts"
 import {
   CommitmentMade,
   OperatorBonded,
+  OperatorConfirmed,
 } from "../generated/TACoApplication/TACoApplication"
 
 export function createOperatorBondedEvent(
@@ -38,6 +39,27 @@ export function createOperatorBondedEvent(
   )
 
   return operatorBondedEvent
+}
+
+export function createOperatorConfirmedEvent(
+  stakingProvider: Address,
+  operator: Address
+): OperatorConfirmed {
+  const operatorConfirmedEvent = changetype<OperatorConfirmed>(newMockEvent())
+
+  operatorConfirmedEvent.parameters = []
+
+  operatorConfirmedEvent.parameters.push(
+    new ethereum.EventParam(
+      "stakingProvider",
+      ethereum.Value.fromAddress(stakingProvider)
+    )
+  )
+  operatorConfirmedEvent.parameters.push(
+    new ethereum.EventParam("operator", ethereum.Value.fromAddress(operator))
+  )
+
+  return operatorConfirmedEvent
 }
 
 export function createCommitmentMadeEvent(

--- a/subgraphs/mainnet/tests/taco-application.test.ts
+++ b/subgraphs/mainnet/tests/taco-application.test.ts
@@ -62,6 +62,12 @@ describe("TACo operators", () => {
         "bondedTimestampFirstOperator",
         firstBondedTimestamp.toString()
       )
+      assert.fieldEquals(
+        "TACoOperator",
+        firstStakingProviderAddr,
+        "confirmed",
+        "false"
+      )
     })
 
     test("bondedTimestamp is updated when operatorBonded event for the same staking provider", () => {
@@ -100,6 +106,12 @@ describe("TACo operators", () => {
         "bondedTimestampFirstOperator",
         firstBondedTimestamp.toString()
       )
+      assert.fieldEquals(
+        "TACoOperator",
+        firstStakingProviderAddr,
+        "confirmed",
+        "false"
+      )
     })
 
     test("a new operator is created when new operatorBonded event", () => {
@@ -122,6 +134,27 @@ describe("TACo operators", () => {
       handleOperatorBonded(operatorBondedEvent)
 
       assert.entityCount("TACoOperator", 2)
+    })
+  })
+
+  describe("OperatorConfirmed event", () => {
+    beforeAll(() => {
+      const stakingProvider = Address.fromString(firstStakingProviderAddr)
+      const operator = Address.fromString(firstOperatorAddr)
+      const previousOperator = Address.fromString(firstPreviousOperatorAddr)
+      const timestamp = BigInt.fromI32(firstBondedTimestamp)
+
+      const operatorBondedEvent = createOperatorBondedEvent(
+        stakingProvider,
+        operator,
+        previousOperator,
+        timestamp
+      )
+      handleOperatorBonded(operatorBondedEvent)
+    })
+
+    afterAll(() => {
+      clearStore()
     })
   })
 })

--- a/subgraphs/mainnet/tests/taco-application.test.ts
+++ b/subgraphs/mainnet/tests/taco-application.test.ts
@@ -10,10 +10,12 @@ import { Address, BigInt } from "@graphprotocol/graph-ts"
 import {
   createCommitmentMadeEvent,
   createOperatorBondedEvent,
+  createOperatorConfirmedEvent,
 } from "./taco-application-utils"
 import {
   handleCommitmentMade,
   handleOperatorBonded,
+  handleOperatorConfirmed,
 } from "../src/taco-application"
 
 const firstStakingProviderAddr = "0x1111111111111111111111111111111111111111"
@@ -155,6 +157,31 @@ describe("TACo operators", () => {
 
     afterAll(() => {
       clearStore()
+    })
+
+    test("operator is marked as confirmed when new operatorConfirmed event", () => {
+      const stakingProvider = Address.fromString(firstStakingProviderAddr)
+      const operator = Address.fromString(firstOperatorAddr)
+
+      assert.fieldEquals(
+        "TACoOperator",
+        firstStakingProviderAddr,
+        "confirmed",
+        "false"
+      )
+
+      const operatorConfirmedEvent = createOperatorConfirmedEvent(
+        stakingProvider,
+        operator
+      )
+      handleOperatorConfirmed(operatorConfirmedEvent)
+
+      assert.fieldEquals(
+        "TACoOperator",
+        firstStakingProviderAddr,
+        "confirmed",
+        "true"
+      )
     })
   })
 })


### PR DESCRIPTION
Since there is a synchronization between TacoApplication and TACoChildApplication done by https://github.com/nucypher/train45, OperatorConfirmed events are now emitted. So we can track them.